### PR TITLE
Get rid of mandatory log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,17 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.9</version>
+            <exclusions>
+            	<exclusion>
+            		<artifactId>slf4j-log4j12</artifactId>
+            		<groupId>org.slf4j</groupId>
+            	</exclusion>
+            	<exclusion>
+            		<artifactId>log4j</artifactId>
+            		<groupId>log4j</groupId>
+            	</exclusion>
+            </exclusions>
         </dependency>
         
         <dependency>
@@ -92,7 +102,14 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.6.4</version>
         </dependency>
-            
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
         	<groupId>org.codehaus.jettison</groupId>
         	<artifactId>jettison</artifactId>

--- a/src/main/java/com/netflix/astyanax/shallows/EmptyConnectionPoolMonitor.java
+++ b/src/main/java/com/netflix/astyanax/shallows/EmptyConnectionPoolMonitor.java
@@ -22,13 +22,15 @@ import com.netflix.astyanax.connectionpool.HostStats;
 
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class EmptyConnectionPoolMonitor implements ConnectionPoolMonitor {
-    private static final Logger LOGGER = Logger
+    private static final Logger LOGGER = LoggerFactory
             .getLogger(EmptyConnectionPoolMonitor.class);
 
-    private static EmptyConnectionPoolMonitor instance = new EmptyConnectionPoolMonitor();
+    private static final EmptyConnectionPoolMonitor instance = new EmptyConnectionPoolMonitor();
 
     public static EmptyConnectionPoolMonitor getInstance() {
         return instance;
@@ -64,23 +66,22 @@ public class EmptyConnectionPoolMonitor implements ConnectionPoolMonitor {
 
     @Override
     public void onHostAdded(Host host, HostConnectionPool<?> pool) {
-        LOGGER.info(String.format("Added host " + host));
+        LOGGER.info("Added host {}", host);
     }
 
     @Override
     public void onHostRemoved(Host host) {
-        LOGGER.info(String.format("Remove host " + host));
+        LOGGER.info("Remove host {}", host);
     }
 
     @Override
     public void onHostDown(Host host, Exception reason) {
-        LOGGER.warn(String.format("Downed host " + host + " reason=\"" + reason
-                + "\""));
+        LOGGER.warn("Downed host {} reason=\"{}\"", host, reason);
     }
 
     @Override
     public void onHostReactivated(Host host, HostConnectionPool<?> pool) {
-        LOGGER.info(String.format("Reactivating host " + host));
+        LOGGER.info("Reactivating host {}", host);
     }
 
     @Override

--- a/src/main/java/com/netflix/astyanax/thrift/ThriftConverter.java
+++ b/src/main/java/com/netflix/astyanax/thrift/ThriftConverter.java
@@ -40,18 +40,19 @@ import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.SliceRange;
 import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.cassandra.thrift.UnavailableException;
-import org.apache.log4j.Logger;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocolException;
 import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 
 public class ThriftConverter {
-    private static final Logger LOGGER = Logger
+    private static final Logger LOGGER = LoggerFactory
             .getLogger(ThriftConverter.class);
 
     /**

--- a/src/test/java/com/netflix/astyanax/connectionpool/impl/BaseConnectionPoolTest.java
+++ b/src/test/java/com/netflix/astyanax/connectionpool/impl/BaseConnectionPoolTest.java
@@ -40,17 +40,18 @@ import com.netflix.astyanax.retry.ConstantBackoff;
 import com.netflix.astyanax.retry.RetryPolicy;
 import com.netflix.astyanax.retry.RunOnce;
 
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Ignore
 public abstract class BaseConnectionPoolTest {
-    private static Logger LOG = Logger
+    private static final Logger LOG = LoggerFactory
             .getLogger(RoundRobinConnectionPoolImplTest.class);
 
-    private static Operation<TestClient, String> dummyOperation = new TestOperation();
+    private static final Operation<TestClient, String> dummyOperation = new TestOperation();
 
     // private static ConnectionPoolConfigurationImpl config;
 
@@ -90,12 +91,12 @@ public abstract class BaseConnectionPoolTest {
             try {
                 OperationResult<String> result = pool.executeWithFailover(
                         dummyOperation, RunOnce.get());
-                LOG.info(result.getHost());
+                LOG.info(result.getHost().toString());
             } catch (OperationException e) {
                 LOG.info(e.getMessage());
                 Assert.fail();
             } catch (ConnectionException e) {
-                LOG.info(e.getCause());
+                LOG.info("", e.getCause());
                 Assert.fail();
             }
         }
@@ -269,7 +270,7 @@ public abstract class BaseConnectionPoolTest {
             ConnectionPool<TestClient> pool = new RoundRobinConnectionPoolImpl<TestClient>(
                     config, new TestConnectionFactory(config, monitor), monitor);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.info("", e);
             Assert.fail();
         }
     }
@@ -299,6 +300,7 @@ public abstract class BaseConnectionPoolTest {
                     dummyOperation, RunOnce.get());
             Assert.assertEquals(host1, result.getHost());
         } catch (Exception e) {
+            LOG.info("", e);
             Assert.fail();
         }
 
@@ -313,7 +315,7 @@ public abstract class BaseConnectionPoolTest {
         } catch (NoAvailableHostsException e) {
 
         } catch (Exception e) {
-            LOG.info(e);
+            LOG.info("", e);
             Assert.fail();
         }
 
@@ -328,6 +330,7 @@ public abstract class BaseConnectionPoolTest {
                     dummyOperation, RunOnce.get());
             Assert.assertEquals(host2, result.getHost());
         } catch (Exception e) {
+            LOG.info("", e);
             Assert.fail();
         }
 
@@ -395,7 +398,7 @@ public abstract class BaseConnectionPoolTest {
             result = pool.executeWithFailover(dummyOperation, RunOnce.get());
             Assert.assertEquals(2, result.getAttemptsCount());
         } catch (ConnectionException e) {
-            LOG.error(e);
+            LOG.error("", e);
             Assert.fail();
         }
     }
@@ -410,7 +413,7 @@ public abstract class BaseConnectionPoolTest {
             Assert.fail();
         } catch (ConnectionException e) {
             Assert.assertEquals(1, retry.getAttemptCount());
-            LOG.error(e);
+            LOG.error(e.getMessage());
         }
 
         retry = new ConstantBackoff(1, 10);
@@ -419,7 +422,7 @@ public abstract class BaseConnectionPoolTest {
             Assert.fail();
         } catch (ConnectionException e) {
             Assert.assertEquals(10, retry.getAttemptCount());
-            LOG.info(e);
+            LOG.info(e.getMessage());
         }
     }
 

--- a/src/test/java/com/netflix/astyanax/connectionpool/impl/RoundRobinConnectionPoolImplTest.java
+++ b/src/test/java/com/netflix/astyanax/connectionpool/impl/RoundRobinConnectionPoolImplTest.java
@@ -31,15 +31,16 @@ import com.netflix.astyanax.fake.TestHostType;
 import com.netflix.astyanax.fake.TestOperation;
 import com.netflix.astyanax.retry.RunOnce;
 
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RoundRobinConnectionPoolImplTest extends BaseConnectionPoolTest {
-    private static Logger LOG = Logger
+    private static final Logger LOG = LoggerFactory
             .getLogger(RoundRobinConnectionPoolImplTest.class);
 
-    private static Operation<TestClient, String> dummyOperation = new TestOperation();
+    private static final Operation<TestClient, String> dummyOperation = new TestOperation();
 
     protected ConnectionPool<TestClient> createPool() {
         CountingConnectionPoolMonitor monitor = new CountingConnectionPoolMonitor();
@@ -156,7 +157,7 @@ public class RoundRobinConnectionPoolImplTest extends BaseConnectionPoolTest {
         } catch (NoAvailableHostsException e) {
 
         } catch (ConnectionException e) {
-            LOG.info(e);
+            LOG.info("", e);
             Assert.fail();
         }
 
@@ -194,7 +195,7 @@ public class RoundRobinConnectionPoolImplTest extends BaseConnectionPoolTest {
             result = cp.executeWithFailover(new TestOperation(), RunOnce.get());
             Assert.fail();
         } catch (ConnectionException e) {
-            LOG.info(e);
+            LOG.info("", e);
         }
 
         think(10000);

--- a/src/test/java/com/netflix/astyanax/connectionpool/impl/StressSimpleHostConnectionPoolImpl.java
+++ b/src/test/java/com/netflix/astyanax/connectionpool/impl/StressSimpleHostConnectionPoolImpl.java
@@ -20,7 +20,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 import com.netflix.astyanax.connectionpool.Connection;
 import com.netflix.astyanax.connectionpool.Host;
@@ -32,7 +34,7 @@ import com.netflix.astyanax.fake.TestConnectionFactory;
 import com.netflix.astyanax.fake.TestHostType;
 
 public class StressSimpleHostConnectionPoolImpl {
-    private static final Logger LOG = Logger.getLogger(Stress.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Stress.class);
 
     public static class NoOpListener implements
             SimpleHostConnectionPool.Listener<TestClient> {


### PR DESCRIPTION
Fix for #34. Use only slf4j in code. log4j can be used by Asyanax user as slf4j implementation.
