### PR TITLE
putColumn simplification, more DRYness, system property for tests

### DIFF
--- a/src/main/java/com/netflix/astyanax/AbstractColumnListMutation.java
+++ b/src/main/java/com/netflix/astyanax/AbstractColumnListMutation.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright 2011 Netflix
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package com.netflix.astyanax;
+
+
+import com.netflix.astyanax.serializers.*;
+
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * Abstract implementation of a row mutation
+ *
+ * @author lucky
+ *
+ * @param <C>
+ */
+public abstract class AbstractColumnListMutation<C> implements ColumnListMutation<C> {
+    protected long timestamp;
+    protected Integer defaultTtl = null;
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, String value, Integer ttl) {
+        return putColumn(columnName, value, StringSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final String value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, byte[] value, Integer ttl) {
+        return putColumn(columnName, value, BytesArraySerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final byte[] value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, int value, Integer ttl) {
+        return putColumn(columnName, value, IntegerSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final int value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, long value, Integer ttl) {
+        return putColumn(columnName, value, LongSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final long value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, boolean value, Integer ttl) {
+        return putColumn(columnName, value, BooleanSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final boolean value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, ByteBuffer value, Integer ttl) {
+        return putColumn(columnName, value, ByteBufferSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final ByteBuffer value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, Date value, Integer ttl) {
+        return putColumn(columnName, value, DateSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final Date value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, float value, Integer ttl) {
+        return putColumn(columnName, value, FloatSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final float value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, double value, Integer ttl) {
+        return putColumn(columnName, value, DoubleSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final double value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(C columnName, UUID value, Integer ttl) {
+        return putColumn(columnName, value, UUIDSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putColumn(final C columnName, final UUID value) {
+        return putColumn(columnName, value, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> putEmptyColumn(final C columnName) {
+        return putEmptyColumn(columnName, null);
+    }
+
+    @Override
+    public ColumnListMutation<C> setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    @Override
+    public ColumnListMutation<C> setDefaultTtl(Integer ttl) {
+        this.defaultTtl = ttl;
+        return this;
+    }
+}

--- a/src/main/java/com/netflix/astyanax/ColumnListMutation.java
+++ b/src/main/java/com/netflix/astyanax/ColumnListMutation.java
@@ -50,26 +50,37 @@ public interface ColumnListMutation<C> {
     <SC> ColumnListMutation<SC> withSuperColumn(ColumnPath<SC> superColumnPath);
 
     ColumnListMutation<C> putColumn(C columnName, String value, Integer ttl);
+    ColumnListMutation<C> putColumn(C columnName, String value);
 
     ColumnListMutation<C> putColumn(C columnName, byte[] value, Integer ttl);
+    ColumnListMutation<C> putColumn(C columnName, byte[] value);
 
     ColumnListMutation<C> putColumn(C columnName, int value, Integer ttl);
+    ColumnListMutation<C> putColumn(C columnName, int value);
 
     ColumnListMutation<C> putColumn(C columnName, long value, Integer ttl);
+    ColumnListMutation<C> putColumn(C columnName, long value);
 
     ColumnListMutation<C> putColumn(C columnName, boolean value, Integer ttl);
+    ColumnListMutation<C> putColumn(C columnName, boolean value);
 
     ColumnListMutation<C> putColumn(C columnName, ByteBuffer value, Integer ttl);
+    ColumnListMutation<C> putColumn(C columnName, ByteBuffer value);
 
     ColumnListMutation<C> putColumn(C columnName, Date value, Integer ttl);
+    ColumnListMutation<C> putColumn(C columnName, Date value);
 
     ColumnListMutation<C> putColumn(C columnName, float value, Integer ttl);
-        
+    ColumnListMutation<C> putColumn(C columnName, float value);
+
     ColumnListMutation<C> putColumn(C columnName, double value, Integer ttl);
+    ColumnListMutation<C> putColumn(C columnName, double value);
 
     ColumnListMutation<C> putColumn(C columnName, UUID value, Integer ttl);
+    ColumnListMutation<C> putColumn(C columnName, UUID value);
 
     ColumnListMutation<C> putEmptyColumn(C columnName, Integer ttl);
+    ColumnListMutation<C> putEmptyColumn(C columnName);
 
     ColumnListMutation<C> incrementCounterColumn(C columnName, long amount);
 

--- a/src/main/java/com/netflix/astyanax/thrift/ThriftColumnFamilyMutationImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/ThriftColumnFamilyMutationImpl.java
@@ -16,10 +16,9 @@
 package com.netflix.astyanax.thrift;
 
 import java.nio.ByteBuffer;
-import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 
+import com.netflix.astyanax.AbstractColumnListMutation;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.CounterColumn;
@@ -30,16 +29,6 @@ import org.apache.cassandra.thrift.SlicePredicate;
 import com.netflix.astyanax.ColumnListMutation;
 import com.netflix.astyanax.Serializer;
 import com.netflix.astyanax.model.ColumnPath;
-import com.netflix.astyanax.serializers.BooleanSerializer;
-import com.netflix.astyanax.serializers.ByteBufferSerializer;
-import com.netflix.astyanax.serializers.BytesArraySerializer;
-import com.netflix.astyanax.serializers.DateSerializer;
-import com.netflix.astyanax.serializers.DoubleSerializer;
-import com.netflix.astyanax.serializers.FloatSerializer;
-import com.netflix.astyanax.serializers.IntegerSerializer;
-import com.netflix.astyanax.serializers.LongSerializer;
-import com.netflix.astyanax.serializers.StringSerializer;
-import com.netflix.astyanax.serializers.UUIDSerializer;
 
 /**
  * Implementation of a row mutation at the root of the column family.
@@ -48,12 +37,10 @@ import com.netflix.astyanax.serializers.UUIDSerializer;
  * 
  * @param <C>
  */
-public class ThriftColumnFamilyMutationImpl<C> implements ColumnListMutation<C> {
+public class ThriftColumnFamilyMutationImpl<C> extends AbstractColumnListMutation<C> {
     private final Serializer<C> columnSerializer;
     private final List<Mutation> mutationList;
-    private long timestamp;
     private SlicePredicate deletionPredicate;
-    private Integer defaultTtl = null;
 
     public ThriftColumnFamilyMutationImpl(Long timestamp, List<Mutation> mutationList, Serializer<C> columnSerializer) {
         this.mutationList = mutationList;
@@ -84,56 +71,6 @@ public class ThriftColumnFamilyMutationImpl<C> implements ColumnListMutation<C> 
         mutationList.add(mutation);
 
         return this;
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, String value, Integer ttl) {
-        return putColumn(columnName, value, StringSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, byte[] value, Integer ttl) {
-        return putColumn(columnName, value, BytesArraySerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, int value, Integer ttl) {
-        return putColumn(columnName, value, IntegerSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, long value, Integer ttl) {
-        return putColumn(columnName, value, LongSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, boolean value, Integer ttl) {
-        return putColumn(columnName, value, BooleanSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, ByteBuffer value, Integer ttl) {
-        return putColumn(columnName, value, ByteBufferSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, Date value, Integer ttl) {
-        return putColumn(columnName, value, DateSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, float value, Integer ttl) {
-        return putColumn(columnName, value, FloatSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, double value, Integer ttl) {
-        return putColumn(columnName, value, DoubleSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, UUID value, Integer ttl) {
-        return putColumn(columnName, value, UUIDSerializer.get(), ttl);
     }
 
     @Override
@@ -193,15 +130,4 @@ public class ThriftColumnFamilyMutationImpl<C> implements ColumnListMutation<C> 
         return this;
     }
 
-    @Override
-    public ColumnListMutation<C> setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
-        return this;
-    }
-
-    @Override
-    public ColumnListMutation<C> setDefaultTtl(Integer ttl) {
-        this.defaultTtl = ttl;
-        return this;
-    }
 }

--- a/src/main/java/com/netflix/astyanax/thrift/ThriftSuperColumnMutationImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/ThriftSuperColumnMutationImpl.java
@@ -15,11 +15,9 @@
  ******************************************************************************/
 package com.netflix.astyanax.thrift;
 
-import java.nio.ByteBuffer;
-import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 
+import com.netflix.astyanax.AbstractColumnListMutation;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.Deletion;
@@ -27,20 +25,9 @@ import org.apache.cassandra.thrift.Mutation;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.SuperColumn;
 
-import com.netflix.astyanax.Clock;
 import com.netflix.astyanax.ColumnListMutation;
 import com.netflix.astyanax.Serializer;
 import com.netflix.astyanax.model.ColumnPath;
-import com.netflix.astyanax.serializers.BooleanSerializer;
-import com.netflix.astyanax.serializers.ByteBufferSerializer;
-import com.netflix.astyanax.serializers.BytesArraySerializer;
-import com.netflix.astyanax.serializers.DateSerializer;
-import com.netflix.astyanax.serializers.DoubleSerializer;
-import com.netflix.astyanax.serializers.FloatSerializer;
-import com.netflix.astyanax.serializers.IntegerSerializer;
-import com.netflix.astyanax.serializers.LongSerializer;
-import com.netflix.astyanax.serializers.StringSerializer;
-import com.netflix.astyanax.serializers.UUIDSerializer;
 
 /**
  * @deprecated Use composite columns instead
@@ -48,13 +35,11 @@ import com.netflix.astyanax.serializers.UUIDSerializer;
  * 
  * @param <C>
  */
-public class ThriftSuperColumnMutationImpl<C> implements ColumnListMutation<C> {
-    private long timestamp;
+public class ThriftSuperColumnMutationImpl<C> extends AbstractColumnListMutation<C> {
     private final List<Mutation> mutationList;
     private final ColumnPath<C> path;
     private SuperColumn superColumn;
     private SlicePredicate deletionPredicate;
-    private Integer defaultTtl = null;
 
     public ThriftSuperColumnMutationImpl(long timestamp, List<Mutation> mutationList, ColumnPath<C> path) {
         this.path = path;
@@ -88,56 +73,6 @@ public class ThriftSuperColumnMutationImpl<C> implements ColumnListMutation<C> {
         }
 
         superColumn.addToColumns(column);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, String value, Integer ttl) {
-        return putColumn(columnName, value, StringSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, byte[] value, Integer ttl) {
-        return putColumn(columnName, value, BytesArraySerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, int value, Integer ttl) {
-        return putColumn(columnName, value, IntegerSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, long value, Integer ttl) {
-        return putColumn(columnName, value, LongSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, boolean value, Integer ttl) {
-        return putColumn(columnName, value, BooleanSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, ByteBuffer value, Integer ttl) {
-        return putColumn(columnName, value, ByteBufferSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, Date value, Integer ttl) {
-        return putColumn(columnName, value, DateSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, float value, Integer ttl) {
-        return putColumn(columnName, value, FloatSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, double value, Integer ttl) {
-        return putColumn(columnName, value, DoubleSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, UUID value, Integer ttl) {
-        return putColumn(columnName, value, UUIDSerializer.get(), ttl);
     }
 
     @Override
@@ -192,15 +127,4 @@ public class ThriftSuperColumnMutationImpl<C> implements ColumnListMutation<C> {
         return this;
     }
 
-    @Override
-    public ColumnListMutation<C> setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
-        return this;
-    }
-
-    @Override
-    public ColumnListMutation<C> setDefaultTtl(Integer ttl) {
-        this.defaultTtl = ttl;
-        return this;
-    }
 }

--- a/src/main/java/com/netflix/astyanax/thrift/model/ThriftCounterSuperColumnMutationImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/model/ThriftCounterSuperColumnMutationImpl.java
@@ -15,11 +15,9 @@
  ******************************************************************************/
 package com.netflix.astyanax.thrift.model;
 
-import java.nio.ByteBuffer;
-import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 
+import com.netflix.astyanax.AbstractColumnListMutation;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.CounterColumn;
 import org.apache.cassandra.thrift.CounterSuperColumn;
@@ -30,19 +28,9 @@ import org.apache.cassandra.thrift.SlicePredicate;
 import com.netflix.astyanax.ColumnListMutation;
 import com.netflix.astyanax.Serializer;
 import com.netflix.astyanax.model.ColumnPath;
-import com.netflix.astyanax.serializers.BooleanSerializer;
-import com.netflix.astyanax.serializers.ByteBufferSerializer;
-import com.netflix.astyanax.serializers.BytesArraySerializer;
-import com.netflix.astyanax.serializers.DateSerializer;
-import com.netflix.astyanax.serializers.DoubleSerializer;
-import com.netflix.astyanax.serializers.FloatSerializer;
-import com.netflix.astyanax.serializers.IntegerSerializer;
-import com.netflix.astyanax.serializers.LongSerializer;
-import com.netflix.astyanax.serializers.StringSerializer;
 import com.netflix.astyanax.serializers.UUIDSerializer;
 
-public class ThriftCounterSuperColumnMutationImpl<C> implements ColumnListMutation<C> {
-    private long timestamp;
+public class ThriftCounterSuperColumnMutationImpl<C> extends AbstractColumnListMutation<C> {
     private final List<Mutation> mutationList;
     private final ColumnPath<C> path;
     private CounterSuperColumn superColumn;
@@ -60,58 +48,13 @@ public class ThriftCounterSuperColumnMutationImpl<C> implements ColumnListMutati
     }
 
     @Override
-    public ColumnListMutation<C> putColumn(C columnName, String value, Integer ttl) {
-        return putColumn(columnName, value, StringSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, byte[] value, Integer ttl) {
-        return putColumn(columnName, value, BytesArraySerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, int value, Integer ttl) {
-        return putColumn(columnName, value, IntegerSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, long value, Integer ttl) {
-        return putColumn(columnName, value, LongSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, boolean value, Integer ttl) {
-        return putColumn(columnName, value, BooleanSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, ByteBuffer value, Integer ttl) {
-        return putColumn(columnName, value, ByteBufferSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, Date value, Integer ttl) {
-        return putColumn(columnName, value, DateSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, float value, Integer ttl) {
-        return putColumn(columnName, value, FloatSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, double value, Integer ttl) {
-        return putColumn(columnName, value, DoubleSerializer.get(), ttl);
-    }
-
-    @Override
-    public ColumnListMutation<C> putColumn(C columnName, UUID value, Integer ttl) {
-        return putColumn(columnName, value, UUIDSerializer.get(), ttl);
-    }
-
-    @Override
     public ColumnListMutation<C> putEmptyColumn(C columnName, Integer ttl) {
         return putColumn(columnName, null, UUIDSerializer.get(), ttl);
+    }
+
+    @Override
+    public ColumnListMutation<C> putEmptyColumn(final C columnName) {
+        return putEmptyColumn(columnName, null);
     }
 
     @Override
@@ -159,12 +102,6 @@ public class ThriftCounterSuperColumnMutationImpl<C> implements ColumnListMutati
         }
 
         deletionPredicate.addToColumn_names(path.getSerializer().toByteBuffer(columnName));
-        return this;
-    }
-
-    @Override
-    public ColumnListMutation<C> setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
         return this;
     }
 

--- a/src/test/java/com/netflix/astyanax/thrift/ThrifeKeyspaceImplTest.java
+++ b/src/test/java/com/netflix/astyanax/thrift/ThrifeKeyspaceImplTest.java
@@ -5,13 +5,7 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -141,11 +135,14 @@ public class ThrifeKeyspaceImplTest {
             .newColumnFamily("ClickStream", StringSerializer.get(),
                     SE_SERIALIZER);
 
-    public static final String SEEDS = "localhost:7102";
+    private static final Properties props = System.getProperties();
+    private static final String seedsPropKey = "astyanax.test.seeds";
+    public static final String SEEDS = props.containsKey(seedsPropKey) ? props.getProperty(seedsPropKey) : "localhost:7102";
 
     @BeforeClass
     public static void setup() throws Exception {
         System.out.println("TESTING THRIFT KEYSPACE");
+
         if (TEST_INIT_KEYSPACE) {
             AstyanaxContext<Cluster> clusterContext = new AstyanaxContext.Builder()
                     .forCluster(TEST_CLUSTER_NAME)


### PR DESCRIPTION
Add `AbstractColumnListMutation<C> implements ColumnListMutation<C>` to simplify and DRY implementations.

Add `putColumn(K, V)` convenience methods that pass through a null ttl.

Use `astyanax.test.seeds` system property to identify seeds for
`ThrifeKeyspaceImplTest`.
