### PR TITLE
added byte array (byte[]) mapping

### DIFF
--- a/src/main/java/com/netflix/astyanax/mapping/Coercions.java
+++ b/src/main/java/com/netflix/astyanax/mapping/Coercions.java
@@ -34,6 +34,8 @@ class Coercions {
             objValue = column.getDateValue();
         } else if (field.getType() == String.class) {
             objValue = column.getStringValue();
+        } else if (field.getType() == byte[].class) {
+            objValue = column.getByteArrayValue();
         } else {
             throw new UnsupportedOperationException();
         }
@@ -76,6 +78,8 @@ class Coercions {
                     mutation.putColumn(columnName, (Date) objValue, null);
                 } else if (objValue.getClass() == String.class) {
                     mutation.putColumn(columnName, (String) objValue, null);
+                } else if(objValue.getClass() == byte[].class) {
+                    mutation.putColumn(columnName, (byte[]) objValue, null);
                 } else {
                     throw new UnsupportedOperationException();
                 }

--- a/src/test/java/com/netflix/astyanax/mapping/FakeKeyspaceBean.java
+++ b/src/test/java/com/netflix/astyanax/mapping/FakeKeyspaceBean.java
@@ -26,6 +26,9 @@ public class FakeKeyspaceBean implements Comparable<FakeKeyspaceBean> {
     @Column("LAST_UPDATE_TS")
     private Long lastUpdateTS;
 
+    @Column("BYTE_ARRAY")
+    private byte[] byteArray;
+
     /**
      * Public empty constructor needed
      */
@@ -163,6 +166,16 @@ public class FakeKeyspaceBean implements Comparable<FakeKeyspaceBean> {
      */
     public void setLastUpdateTS(Long updateTimestamp) {
         lastUpdateTS = updateTimestamp;
+    }
+
+    public byte[] getByteArray()
+    {
+        return byteArray;
+    }
+
+    public void setByteArray(byte[] byteArray)
+    {
+        this.byteArray = byteArray;
     }
 
     /**

--- a/src/test/java/com/netflix/astyanax/mapping/TestMapping.java
+++ b/src/test/java/com/netflix/astyanax/mapping/TestMapping.java
@@ -15,6 +15,7 @@ public class TestMapping {
         override.setLastUpdateTS(24681357L);
         override.setType("thing");
         override.setUpdatedBy("John Galt");
+        override.setByteArray("Some Bytes".getBytes());
 
         Mapping<FakeKeyspaceBean> mapping = Mapping
                 .make(FakeKeyspaceBean.class);
@@ -43,6 +44,9 @@ public class TestMapping {
         Assert.assertEquals(
                 mapping.getColumnValue(override, "UPDATED_BY", String.class),
                 override.getUpdatedBy());
+        Assert.assertEquals(
+                mapping.getColumnValue(override, "BYTE_ARRAY", byte[].class),
+                override.getByteArray());
 
         FakeKeyspaceBean copy = new FakeKeyspaceBean();
         for (String fieldName : mapping.getNames()) {
@@ -59,6 +63,7 @@ public class TestMapping {
         Assert.assertEquals(copy.getLastUpdateTS(), override.getLastUpdateTS());
         Assert.assertEquals(copy.getType(), override.getType());
         Assert.assertEquals(copy.getUpdatedBy(), override.getUpdatedBy());
+        Assert.assertEquals(copy.getByteArray(), override.getByteArray());
     }
 
     @Test


### PR DESCRIPTION
Now byte[]s can be mapped like ints and Strings. 

```
@Column("BYTE_ARRAY_COLUMN_NAME")
private byte[] byteArray;
```

After this pull request the following types can be mapped:
- `Byte.class` and `Byte.TYPE` (primitive `byte`)
- `Boolean.class` and `Boolean.TYPE` (primitive `boolean`)
- `Short.class` and `Short.TYPE` (primitive `short`)
- `Integer.class` and `Integer.TYPE` (primitive `int`)
- `Long.class` and `Long.TYPE` (primitive `long`)
- `Float.class` and `Float.TYPE` (primitive `float`)
- `Double.class` and `Double.TYPE` (primitive `double`)
- `Date.class`
- `String.class`
- `byte[].class` (byte arrays, new with this pull request)
