### PR TITLE
Don't allow Host to default to hostname None and IP 0.0.0.0

### DIFF
--- a/src/main/java/com/netflix/astyanax/connectionpool/Host.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/Host.java
@@ -64,8 +64,7 @@ public class Host {
                 workIpAddress = address.getHostAddress();
             }
             catch (UnknownHostException e) {
-                workHost = tempHost;
-                workIpAddress = tempHost;
+                throw new RuntimeException(e);
             }
         }
         this.host = workHost;


### PR DESCRIPTION
Raises an RTE that wraps the UnknownHostException. This causes a massive debug headache when name resolution fails. Also, 0.0.0.0 is not a safe default
