### PR TITLE
Fix for issue #92

### DIFF
--- a/src/main/java/com/netflix/astyanax/serializers/IntegerSerializer.java
+++ b/src/main/java/com/netflix/astyanax/serializers/IntegerSerializer.java
@@ -2,8 +2,6 @@ package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;
 
-import org.apache.cassandra.db.marshal.IntegerType;
-
 /**
  * Converts bytes to Integer and vice versa
  * 
@@ -41,9 +39,18 @@ public final class IntegerSerializer extends AbstractSerializer<Integer> {
 
     @Override
     public Integer fromBytes(byte[] bytes) {
-        if ((bytes == null) || (bytes.length != 4)) {
+        if (bytes == null || bytes.length > 4) {
             return null;
         }
+        else if (bytes.length < 4) {
+            byte[] newBytes = new byte[4];
+
+            for (int i = bytes.length - 1; i >= 0; i--) {
+                newBytes[i + 4 - bytes.length] = bytes[i];
+            }
+            bytes = newBytes;
+        }
+
         ByteBuffer bb = ByteBuffer.allocate(4).put(bytes, 0, 4);
         bb.rewind();
         return bb.getInt();

--- a/src/main/java/com/netflix/astyanax/serializers/LongSerializer.java
+++ b/src/main/java/com/netflix/astyanax/serializers/LongSerializer.java
@@ -41,6 +41,25 @@ public final class LongSerializer extends AbstractSerializer<Long> {
     }
 
     @Override
+    public Long fromBytes(byte[] bytes) {
+        if (bytes == null || bytes.length > 8) {
+            return null;
+        }
+        else if (bytes.length < 8) {
+            byte[] newBytes = new byte[8];
+
+            for (int i = bytes.length - 1; i >= 0; i--) {
+                newBytes[i + 8 - bytes.length] = bytes[i];
+            }
+            bytes = newBytes;
+        }
+
+        ByteBuffer bb = ByteBuffer.allocate(8).put(bytes, 0, 8);
+        bb.rewind();
+        return bb.getLong();
+    }
+
+    @Override
     public ComparatorType getComparatorType() {
         return ComparatorType.LONGTYPE;
     }


### PR DESCRIPTION
This is a fix for issue #92 in your issue tracker.  Basically, when the Cassandra CLI creates an Integer or a Long, it's too short for Astyanax, and Astyanax complains.  This fix pads out the byte array as necessary.
