### PR TITLE
RoundRobinExecuteWithFailover: int overflow fix.

### DIFF
--- a/src/main/java/com/netflix/astyanax/connectionpool/impl/RoundRobinExecuteWithFailover.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/impl/RoundRobinExecuteWithFailover.java
@@ -46,6 +46,8 @@ public class RoundRobinExecuteWithFailover<CL, R> extends AbstractExecuteWithFai
         }
         finally {
             index++;
+            if (index < 0)
+                index = 0;
         }
     }
 


### PR DESCRIPTION
Java modulus (%) can be negative. Handle that case after 2^31 connection pool checkouts.
