### PR TITLE
Consistency level switching has been added to improve data availability

### DIFF
--- a/src/main/java/com/netflix/astyanax/AstyanaxConfiguration.java
+++ b/src/main/java/com/netflix/astyanax/AstyanaxConfiguration.java
@@ -19,7 +19,7 @@ import java.util.concurrent.ExecutorService;
 
 import com.netflix.astyanax.connectionpool.NodeDiscoveryType;
 import com.netflix.astyanax.connectionpool.impl.ConnectionPoolType;
-import com.netflix.astyanax.model.ConsistencyLevel;
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
 import com.netflix.astyanax.retry.RetryPolicy;
 
 /**
@@ -37,23 +37,17 @@ public interface AstyanaxConfiguration {
     RetryPolicy getRetryPolicy();
 
     /**
-     * Default consistency level used when reading from the cluster. This value
-     * can be overwritten on the Query operations (returned by
-     * Keyspace.prepareXXQuery) by calling Query.setConsistencyLevel().
+     * Default consistency level policy used when reading or writing from the cluster.
+     * This value can be overwritten: <br/>
+     * <p>on Query operations (returned by
+     * Keyspace.prepareXXQuery) by calling Query.setConsistencyLevelPolicy()</p>
+     * <p>on MutationBatch operation (returned by Keyspace.prepareMutationBatch) by calling
+     * MutationBatch.setConsistencyLevelPolicy().</p>
+     * <p>on operation by calling Operation.setConsistencyLevelPolicy()</p>
      * 
-     * @return
+     * @return the current value of the default  consistency level policy
      */
-    ConsistencyLevel getDefaultReadConsistencyLevel();
-
-    /**
-     * Default consistency level used when reading from the cluster. This value
-     * can be overwritten on MutationBatch operation (returned by
-     * Keyspace.prepareMutationBatch) by calling
-     * MutationBatch.setConsistencyLevel().
-     * 
-     * @return
-     */
-    ConsistencyLevel getDefaultWriteConsistencyLevel();
+    ConsistencyLevelPolicy getDefaultConsistencyLevelPolicy();
 
     /**
      * Return clock to use when setting timestamps for column insertion and

--- a/src/main/java/com/netflix/astyanax/ColumnMutation.java
+++ b/src/main/java/com/netflix/astyanax/ColumnMutation.java
@@ -15,15 +15,15 @@
  ******************************************************************************/
 package com.netflix.astyanax;
 
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
+import com.netflix.astyanax.retry.RetryPolicy;
+
 import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.UUID;
 
-import com.netflix.astyanax.model.ConsistencyLevel;
-import com.netflix.astyanax.retry.RetryPolicy;
-
 public interface ColumnMutation {
-    ColumnMutation setConsistencyLevel(ConsistencyLevel consistencyLevel);
+    ColumnMutation setConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy);
 
     ColumnMutation withRetryPolicy(RetryPolicy retry);
 

--- a/src/main/java/com/netflix/astyanax/MutationBatch.java
+++ b/src/main/java/com/netflix/astyanax/MutationBatch.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.Set;
 
 import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
 import com.netflix.astyanax.model.ColumnFamily;
-import com.netflix.astyanax.model.ConsistencyLevel;
 import com.netflix.astyanax.retry.RetryPolicy;
 
 /**
@@ -142,20 +142,20 @@ public interface MutationBatch extends Execution<Void> {
     MutationBatch pinToHost(Host host);
 
     /**
-     * Set the consistency level for this mutation (same as withConsistencyLevel)
+     * Set the consistency level policy for this mutation (same as withConsistencyLevelPolicy)
      * 
-     * @param consistencyLevel
+     * @param consistencyLevelPolicy
      */
-    MutationBatch setConsistencyLevel(ConsistencyLevel consistencyLevel);
-    
+    MutationBatch setConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy);
+
     /**
-     * Set the consistency level for this mutation (same as setConsistencyLevel)
+     * Set the consistency level policy for this mutation (same as setConsistencyLevelPolicy)
      * 
-     * @param consistencyLevel
+     * @param consistencyLevelPolicy
      * @return
      */
-    MutationBatch withConsistencyLevel(ConsistencyLevel consistencyLevel);
-
+    MutationBatch withConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy);
+    
     /**
      * Set the retry policy to use instead of the one specified in the
      * configuration

--- a/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolConfiguration.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolConfiguration.java
@@ -269,4 +269,11 @@ public interface ConnectionPoolConfiguration {
      * @return
      */
     Partitioner getPartitioner();
+
+    /**
+     * The current consistency level handler
+     *
+     * @return the current instance of {@link HostDownConsistencyHandler}
+     */
+    HostDownConsistencyHandler getHostDownConsistencyHandler();
 }

--- a/src/main/java/com/netflix/astyanax/connectionpool/ConsistencyLevelPolicyHolder.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/ConsistencyLevelPolicyHolder.java
@@ -1,0 +1,22 @@
+package com.netflix.astyanax.connectionpool;
+
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
+
+/**
+ * @author Max Morozov
+ */
+public interface ConsistencyLevelPolicyHolder {
+    /**
+     * Gets the consistency level policy of this operation.
+     *
+     * @return an object that keeps consistency levels for read and write operations
+     */
+    ConsistencyLevelPolicy getConsistencyLevelPolicy();
+
+    /**
+     * Set consistency level policy for this operation.
+     *
+     * @param consistencyLevelPolicy object that keeps consistency levels for read and write operations
+     */
+    void setConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy);
+}

--- a/src/main/java/com/netflix/astyanax/connectionpool/HostDownConsistencyHandler.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/HostDownConsistencyHandler.java
@@ -1,0 +1,19 @@
+package com.netflix.astyanax.connectionpool;
+
+import com.netflix.astyanax.connectionpool.impl.HostConnectionPoolPartition;
+
+/**
+ * Handles events from the pool manager about downed and recovered hosts, and
+ * modifies operations' consistency level to improve availability
+ *
+ * @author Max Morozov
+ */
+public interface HostDownConsistencyHandler {
+    /**
+     * Returns the consistency level policy that can be provided with the current
+     *
+     * @param obj         an object that should be processed and which consistency level is subject to change
+     * @param partition   partition where the request will be executed
+     */
+    <CL> void handle(ConsistencyLevelPolicyHolder obj, HostConnectionPoolPartition<CL> partition);
+}

--- a/src/main/java/com/netflix/astyanax/connectionpool/Operation.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/Operation.java
@@ -29,7 +29,7 @@ import com.netflix.astyanax.connectionpool.exceptions.OperationException;
  * @param <C>
  * @param <R>
  */
-public interface Operation<CL, R> {
+public interface Operation<CL, R> extends ConsistencyLevelPolicyHolder {
     /**
      * Execute the operation on the client object and return the results
      * 
@@ -60,8 +60,7 @@ public interface Operation<CL, R> {
      * Return the host to run on or null to select a host using the load
      * blancer. Failover is disabled for this scenario.
      * 
-     * @param host
-     * @return
+     * @return host
      */
     Host getPinnedHost();
 }

--- a/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractOperationFilter.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractOperationFilter.java
@@ -5,9 +5,12 @@ import java.nio.ByteBuffer;
 import com.netflix.astyanax.connectionpool.Host;
 import com.netflix.astyanax.connectionpool.Operation;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
+import com.netflix.astyanax.consistency.OneOneConsistencyLevelPolicy;
 
 public class AbstractOperationFilter<R, CL> implements Operation<R, CL>{
 
+    private ConsistencyLevelPolicy consistencyLevelPolicy = OneOneConsistencyLevelPolicy.get();
     private Operation<R, CL> next;
     
     public AbstractOperationFilter(Operation<R, CL> next) {
@@ -34,4 +37,23 @@ public class AbstractOperationFilter<R, CL> implements Operation<R, CL>{
         return next.getPinnedHost();
     }
 
+    /**
+     * Gets the consistency level policy of this operation.
+     *
+     * @return an object that keeps consistency levels for read and write operations
+     */
+    @Override
+    public ConsistencyLevelPolicy getConsistencyLevelPolicy() {
+        return consistencyLevelPolicy;
+    }
+
+    /**
+     * Set consistency level policy for this operation.
+     *
+     * @param consistencyLevelPolicy object that keeps consistency levels for read and write operations
+     */
+    @Override
+    public void setConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy) {
+        this.consistencyLevelPolicy = consistencyLevelPolicy;
+    }
 }

--- a/src/main/java/com/netflix/astyanax/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 Netflix
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,12 +20,7 @@ import java.util.List;
 
 import com.google.common.base.Preconditions;
 import com.netflix.astyanax.AuthenticationCredentials;
-import com.netflix.astyanax.connectionpool.BadHostDetector;
-import com.netflix.astyanax.connectionpool.ConnectionPoolConfiguration;
-import com.netflix.astyanax.connectionpool.Host;
-import com.netflix.astyanax.connectionpool.LatencyScoreStrategy;
-import com.netflix.astyanax.connectionpool.OperationFilterFactory;
-import com.netflix.astyanax.connectionpool.RetryBackoffStrategy;
+import com.netflix.astyanax.connectionpool.*;
 import com.netflix.astyanax.partitioner.BigInteger127Partitioner;
 import com.netflix.astyanax.partitioner.Partitioner;
 import com.netflix.astyanax.shallows.EmptyBadHostDetectorImpl;
@@ -100,6 +95,8 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
     private AuthenticationCredentials credentials         = null;
     private OperationFilterFactory filterFactory          = EmptyOperationFilterFactory.getInstance();
     private Partitioner partitioner                       = DEFAULT_PARTITIONER;
+
+    private HostDownConsistencyHandler hostDownConsistencyHandler = new DefaultHostDownConsistencyHandler();
 
     public ConnectionPoolConfigurationImpl(String name) {
         this.name = name;
@@ -507,6 +504,21 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
     public ConnectionPoolConfigurationImpl setMinHostInPoolRatio(float ratio) {
         this.minHostInPoolRatio = ratio;
         return this;
+    }
+    
+    public ConnectionPoolConfigurationImpl setHostDownConsistencyLevelHandler(HostDownConsistencyHandler hostDownConsistencyHandler) {
+        this.hostDownConsistencyHandler = hostDownConsistencyHandler;
+        return this;
+    }
+
+    /**
+     * The current consistency level handler
+     *
+     * @return the current instance of {@link HostDownConsistencyHandler}
+     */
+    @Override
+    public HostDownConsistencyHandler getHostDownConsistencyHandler() {
+        return hostDownConsistencyHandler;
     }
 
 }

--- a/src/main/java/com/netflix/astyanax/connectionpool/impl/DefaultHostDownConsistencyHandler.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/impl/DefaultHostDownConsistencyHandler.java
@@ -1,0 +1,22 @@
+package com.netflix.astyanax.connectionpool.impl;
+
+import com.netflix.astyanax.connectionpool.ConsistencyLevelPolicyHolder;
+import com.netflix.astyanax.connectionpool.HostDownConsistencyHandler;
+
+/**
+ * The default implementation that just return the required consistency level policy
+ *
+ * @author Max Morozov
+ */
+public class DefaultHostDownConsistencyHandler implements HostDownConsistencyHandler {
+    /**
+     * Returns the consistency level policy that can be provided with the current
+     *
+     * @param obj         an object that should be processed and which consistency level is subject to change
+     * @param partition   partition where the request will be executed
+     */
+    @Override
+    public <CL> void handle(ConsistencyLevelPolicyHolder obj, HostConnectionPoolPartition<CL> partition) {
+        //Do nothing
+    }
+}

--- a/src/main/java/com/netflix/astyanax/connectionpool/impl/FixedRetryBackoffStrategy.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/impl/FixedRetryBackoffStrategy.java
@@ -57,6 +57,7 @@ public class FixedRetryBackoffStrategy implements RetryBackoffStrategy {
 
             @Override
             public void suspend() {
+                isSuspended = true;
             }
         };
     }

--- a/src/main/java/com/netflix/astyanax/connectionpool/impl/HostConnectionPoolPartition.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/impl/HostConnectionPoolPartition.java
@@ -94,6 +94,10 @@ public class HostConnectionPoolPartition<CL> {
     public List<HostConnectionPool<CL>> getPools() {
         return activePools.get();
     }
+
+    public Set<HostConnectionPool<CL>> getAllPools() {
+        return pools;
+    }
     
     /**
      * If true the the hosts are sorted by order of priority where the 

--- a/src/main/java/com/netflix/astyanax/consistency/ConsistencyLevelPolicy.java
+++ b/src/main/java/com/netflix/astyanax/consistency/ConsistencyLevelPolicy.java
@@ -1,0 +1,11 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+/**
+ * The object that keeps read and write consistency levels together
+ */
+public interface ConsistencyLevelPolicy {
+    ConsistencyLevel getReadConsistencyLevel();
+    ConsistencyLevel getWriteConsistencyLevel();
+}

--- a/src/main/java/com/netflix/astyanax/consistency/LQuorumLQuorumConsistencyLevelPolicy.java
+++ b/src/main/java/com/netflix/astyanax/consistency/LQuorumLQuorumConsistencyLevelPolicy.java
@@ -1,0 +1,27 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+public final class LQuorumLQuorumConsistencyLevelPolicy implements ConsistencyLevelPolicy {
+
+    private LQuorumLQuorumConsistencyLevelPolicy() {
+    }
+
+    @Override
+    public ConsistencyLevel getReadConsistencyLevel() {
+        return ConsistencyLevel.CL_LOCAL_QUORUM;
+    }
+
+    @Override
+    public ConsistencyLevel getWriteConsistencyLevel() {
+        return ConsistencyLevel.CL_LOCAL_QUORUM;
+    }
+
+    private static class PolicyHolder {
+        static final ConsistencyLevelPolicy policy = new LQuorumLQuorumConsistencyLevelPolicy();
+    }
+
+    public static ConsistencyLevelPolicy get() {
+        return PolicyHolder.policy;
+    }
+}

--- a/src/main/java/com/netflix/astyanax/consistency/OneAllConsistencyLevelPolicy.java
+++ b/src/main/java/com/netflix/astyanax/consistency/OneAllConsistencyLevelPolicy.java
@@ -1,0 +1,27 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+public final class OneAllConsistencyLevelPolicy implements ConsistencyLevelPolicy {
+
+    private OneAllConsistencyLevelPolicy() {
+    }
+
+    @Override
+    public ConsistencyLevel getReadConsistencyLevel() {
+        return ConsistencyLevel.CL_ONE;
+    }
+
+    @Override
+    public ConsistencyLevel getWriteConsistencyLevel() {
+        return ConsistencyLevel.CL_ALL;
+    }
+
+    private static class PolicyHolder {
+        static final ConsistencyLevelPolicy policy = new OneAllConsistencyLevelPolicy();
+    }
+
+    public static ConsistencyLevelPolicy get() {
+        return PolicyHolder.policy;
+    }
+}

--- a/src/main/java/com/netflix/astyanax/consistency/OneLQuorumConsistencyLevelPolicy.java
+++ b/src/main/java/com/netflix/astyanax/consistency/OneLQuorumConsistencyLevelPolicy.java
@@ -1,0 +1,28 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+public final class OneLQuorumConsistencyLevelPolicy implements ConsistencyLevelPolicy {
+
+    private OneLQuorumConsistencyLevelPolicy() {
+    }
+
+    @Override
+    public ConsistencyLevel getReadConsistencyLevel() {
+        return ConsistencyLevel.CL_ONE;
+    }
+
+    @Override
+    public ConsistencyLevel getWriteConsistencyLevel() {
+        return ConsistencyLevel.CL_LOCAL_QUORUM;
+    }
+
+    private static class PolicyHolder {
+        static final ConsistencyLevelPolicy policy = new OneLQuorumConsistencyLevelPolicy();
+    }
+
+    public static ConsistencyLevelPolicy get() {
+        return PolicyHolder.policy;
+    }
+
+}

--- a/src/main/java/com/netflix/astyanax/consistency/OneOneConsistencyLevelPolicy.java
+++ b/src/main/java/com/netflix/astyanax/consistency/OneOneConsistencyLevelPolicy.java
@@ -1,0 +1,27 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+public final class OneOneConsistencyLevelPolicy implements ConsistencyLevelPolicy {
+
+    private OneOneConsistencyLevelPolicy() {
+    }
+
+    @Override
+    public ConsistencyLevel getReadConsistencyLevel() {
+        return ConsistencyLevel.CL_ONE;
+    }
+
+    @Override
+    public ConsistencyLevel getWriteConsistencyLevel() {
+        return ConsistencyLevel.CL_ONE;
+    }
+
+    private static class PolicyHolder {
+        static final ConsistencyLevelPolicy policy = new OneOneConsistencyLevelPolicy();
+    }
+
+    public static ConsistencyLevelPolicy get() {
+        return PolicyHolder.policy;
+    }
+}

--- a/src/main/java/com/netflix/astyanax/consistency/OneQuorumConsistencyLevelPolicy.java
+++ b/src/main/java/com/netflix/astyanax/consistency/OneQuorumConsistencyLevelPolicy.java
@@ -1,0 +1,28 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+public final class OneQuorumConsistencyLevelPolicy implements ConsistencyLevelPolicy {
+
+    private OneQuorumConsistencyLevelPolicy() {
+    }
+
+    @Override
+    public ConsistencyLevel getReadConsistencyLevel() {
+        return ConsistencyLevel.CL_ONE;
+    }
+
+    @Override
+    public ConsistencyLevel getWriteConsistencyLevel() {
+        return ConsistencyLevel.CL_QUORUM;
+    }
+
+    private static class PolicyHolder {
+        static final ConsistencyLevelPolicy policy = new OneQuorumConsistencyLevelPolicy();
+    }
+
+    public static ConsistencyLevelPolicy get() {
+        return PolicyHolder.policy;
+    }
+
+}

--- a/src/main/java/com/netflix/astyanax/consistency/OneTwoConsistencyLevelPolicy.java
+++ b/src/main/java/com/netflix/astyanax/consistency/OneTwoConsistencyLevelPolicy.java
@@ -1,0 +1,27 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+public final class OneTwoConsistencyLevelPolicy implements ConsistencyLevelPolicy {
+
+    private OneTwoConsistencyLevelPolicy() {
+    }
+
+    @Override
+    public ConsistencyLevel getReadConsistencyLevel() {
+        return ConsistencyLevel.CL_ONE;
+    }
+
+    @Override
+    public ConsistencyLevel getWriteConsistencyLevel() {
+        return ConsistencyLevel.CL_TWO;
+    }
+
+    private static class PolicyHolder {
+        static final ConsistencyLevelPolicy policy = new OneTwoConsistencyLevelPolicy();
+    }
+
+    public static ConsistencyLevelPolicy get() {
+        return PolicyHolder.policy;
+    }
+}

--- a/src/main/java/com/netflix/astyanax/consistency/QuorumQuorumConsistencyLevelPolicy.java
+++ b/src/main/java/com/netflix/astyanax/consistency/QuorumQuorumConsistencyLevelPolicy.java
@@ -1,0 +1,27 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+public final class QuorumQuorumConsistencyLevelPolicy implements ConsistencyLevelPolicy {
+
+    private QuorumQuorumConsistencyLevelPolicy() {
+    }
+
+    @Override
+    public ConsistencyLevel getReadConsistencyLevel() {
+        return ConsistencyLevel.CL_QUORUM;
+    }
+
+    @Override
+    public ConsistencyLevel getWriteConsistencyLevel() {
+        return ConsistencyLevel.CL_QUORUM;
+    }
+
+    private static class PolicyHolder {
+        static final ConsistencyLevelPolicy policy = new QuorumQuorumConsistencyLevelPolicy();
+    }
+
+    public static ConsistencyLevelPolicy get() {
+        return PolicyHolder.policy;
+    }
+}

--- a/src/main/java/com/netflix/astyanax/impl/AstyanaxConfigurationImpl.java
+++ b/src/main/java/com/netflix/astyanax/impl/AstyanaxConfigurationImpl.java
@@ -9,14 +9,14 @@ import com.netflix.astyanax.Clock;
 import com.netflix.astyanax.clock.MicrosecondsSyncClock;
 import com.netflix.astyanax.connectionpool.NodeDiscoveryType;
 import com.netflix.astyanax.connectionpool.impl.ConnectionPoolType;
-import com.netflix.astyanax.model.ConsistencyLevel;
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
+import com.netflix.astyanax.consistency.OneOneConsistencyLevelPolicy;
 import com.netflix.astyanax.retry.RetryPolicy;
 import com.netflix.astyanax.retry.RunOnce;
 import com.netflix.astyanax.util.StringUtils;
 
 public class AstyanaxConfigurationImpl implements AstyanaxConfiguration {
-    private ConsistencyLevel defaultReadConsistencyLevel = ConsistencyLevel.CL_ONE;
-    private ConsistencyLevel defaultWriteConsistencyLevel = ConsistencyLevel.CL_ONE;
+    private ConsistencyLevelPolicy defaultConsistencyLevelPolicy = OneOneConsistencyLevelPolicy.get();
     private Clock clock = new MicrosecondsSyncClock();
     private RetryPolicy retryPolicy = RunOnce.get();
     private ExecutorService asyncExecutor = Executors.newFixedThreadPool(5, 
@@ -39,26 +39,6 @@ public class AstyanaxConfigurationImpl implements AstyanaxConfiguration {
     @Override
     public ConnectionPoolType getConnectionPoolType() {
         return this.connectionPoolType;
-    }
-
-    @Override
-    public ConsistencyLevel getDefaultReadConsistencyLevel() {
-        return this.defaultReadConsistencyLevel;
-    }
-
-    public AstyanaxConfigurationImpl setDefaultReadConsistencyLevel(ConsistencyLevel cl) {
-        this.defaultReadConsistencyLevel = cl;
-        return this;
-    }
-
-    @Override
-    public ConsistencyLevel getDefaultWriteConsistencyLevel() {
-        return this.defaultWriteConsistencyLevel;
-    }
-
-    public AstyanaxConfigurationImpl setDefaultWriteConsistencyLevel(ConsistencyLevel cl) {
-        this.defaultWriteConsistencyLevel = cl;
-        return this;
     }
 
     @Override
@@ -89,6 +69,16 @@ public class AstyanaxConfigurationImpl implements AstyanaxConfiguration {
 
     public AstyanaxConfigurationImpl setRetryPolicy(RetryPolicy retryPolicy) {
         this.retryPolicy = retryPolicy;
+        return this;
+    }
+
+    @Override
+    public ConsistencyLevelPolicy getDefaultConsistencyLevelPolicy() {
+        return defaultConsistencyLevelPolicy;
+    }
+
+    public AstyanaxConfigurationImpl setDefaultConsistencyLevelPolicy(ConsistencyLevelPolicy defaultConsistencyLevelPolicy) {
+        this.defaultConsistencyLevelPolicy = defaultConsistencyLevelPolicy;
         return this;
     }
 

--- a/src/main/java/com/netflix/astyanax/query/ColumnFamilyQuery.java
+++ b/src/main/java/com/netflix/astyanax/query/ColumnFamilyQuery.java
@@ -18,7 +18,7 @@ package com.netflix.astyanax.query;
 import java.util.Collection;
 
 import com.netflix.astyanax.connectionpool.Host;
-import com.netflix.astyanax.model.ConsistencyLevel;
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
 import com.netflix.astyanax.retry.RetryPolicy;
 
 /**
@@ -32,17 +32,17 @@ import com.netflix.astyanax.retry.RetryPolicy;
  */
 public interface ColumnFamilyQuery<K, C> {
     /**
-     * Set the consistency level for this operations.
+     * Set the consistency level policy for this operations.
      * 
-     * @param consistencyLevel
+     * @param consistencyLevelPolicy
      * @return
      */
-    ColumnFamilyQuery<K, C> setConsistencyLevel(ConsistencyLevel consistencyLevel);
+    ColumnFamilyQuery<K, C> setConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy);
 
     /**
      * Set the retry policy to use instead of the default
      * 
-     * @param consistencyLevel
+     * @param retry
      * @return
      */
     ColumnFamilyQuery<K, C> withRetryPolicy(RetryPolicy retry);
@@ -119,7 +119,6 @@ public interface ColumnFamilyQuery<K, C> {
     /**
      * Search for keys matching the provided index clause
      * 
-     * @param indexClause
      * @return
      */
     IndexQuery<K, C> searchWithIndex();

--- a/src/main/java/com/netflix/astyanax/recipes/storage/CassandraChunkedStorageProvider.java
+++ b/src/main/java/com/netflix/astyanax/recipes/storage/CassandraChunkedStorageProvider.java
@@ -8,6 +8,7 @@ import com.netflix.astyanax.ColumnListMutation;
 import com.netflix.astyanax.Keyspace;
 import com.netflix.astyanax.MutationBatch;
 import com.netflix.astyanax.connectionpool.exceptions.NotFoundException;
+import com.netflix.astyanax.consistency.OneOneConsistencyLevelPolicy;
 import com.netflix.astyanax.model.ColumnFamily;
 import com.netflix.astyanax.model.ColumnList;
 import com.netflix.astyanax.model.ConsistencyLevel;
@@ -86,7 +87,7 @@ public class CassandraChunkedStorageProvider implements ChunkedStorageProvider {
 
     @Override
     public ByteBuffer readChunk(String objectName, int chunkId) throws Exception {
-        return keyspace.prepareQuery(cf).setConsistencyLevel(ConsistencyLevel.CL_ONE).withRetryPolicy(retryPolicy)
+        return keyspace.prepareQuery(cf).setConsistencyLevelPolicy(OneOneConsistencyLevelPolicy.get()).withRetryPolicy(retryPolicy)
                 .getKey(getRowKey(objectName, chunkId)).getColumn(getColumnName(Columns.DATA)).execute().getResult()
                 .getByteBufferValue();
     }

--- a/src/main/java/com/netflix/astyanax/recipes/uniqueness/ColumnPrefixUniquenessConstraint.java
+++ b/src/main/java/com/netflix/astyanax/recipes/uniqueness/ColumnPrefixUniquenessConstraint.java
@@ -5,8 +5,8 @@ import java.util.Map.Entry;
 import com.netflix.astyanax.Keyspace;
 import com.netflix.astyanax.MutationBatch;
 import com.netflix.astyanax.connectionpool.exceptions.NotFoundException;
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
 import com.netflix.astyanax.model.ColumnFamily;
-import com.netflix.astyanax.model.ConsistencyLevel;
 import com.netflix.astyanax.recipes.locks.ColumnPrefixDistributedRowLock;
 
 /**
@@ -30,8 +30,8 @@ public class ColumnPrefixUniquenessConstraint<K> implements UniquenessConstraint
         return this;
     }
 
-    public ColumnPrefixUniquenessConstraint<K> withConsistencyLevel(ConsistencyLevel consistencyLevel) {
-        lock.withConsistencyLevel(consistencyLevel);
+    public ColumnPrefixUniquenessConstraint<K> withConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy) {
+        lock.withConsistencyLevelPolicy(consistencyLevelPolicy);
         return this;
     }
 
@@ -85,7 +85,7 @@ public class ColumnPrefixUniquenessConstraint<K> implements UniquenessConstraint
         m.lockCurrentTimestamp();
         lock.fillReleaseMutation(m, true);
         lock.fillLockMutation(m, null, null);
-        m.setConsistencyLevel(lock.getConsistencyLevel())
+        m.setConsistencyLevelPolicy(lock.getConsistencyLevelPolicy())
             .execute();
     }
     

--- a/src/main/java/com/netflix/astyanax/test/TestOperation.java
+++ b/src/main/java/com/netflix/astyanax/test/TestOperation.java
@@ -21,6 +21,8 @@ import com.netflix.astyanax.connectionpool.Host;
 import com.netflix.astyanax.connectionpool.Operation;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.netflix.astyanax.connectionpool.exceptions.OperationException;
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
+import com.netflix.astyanax.consistency.OneOneConsistencyLevelPolicy;
 
 public class TestOperation implements Operation<TestClient, String> {
     @Override
@@ -42,5 +44,19 @@ public class TestOperation implements Operation<TestClient, String> {
     @Override
     public Host getPinnedHost() {
         return null;
+    }
+
+    /**
+     * Gets the consistency level policy of this operation.
+     *
+     * @return an object that keeps consistency levels for read and write operations
+     */
+    @Override
+    public ConsistencyLevelPolicy getConsistencyLevelPolicy() {
+        return OneOneConsistencyLevelPolicy.get();
+    }
+
+    @Override
+    public void setConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy) {
     }
 }

--- a/src/main/java/com/netflix/astyanax/thrift/AbstractKeyspaceOperationImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/AbstractKeyspaceOperationImpl.java
@@ -17,17 +17,18 @@ package com.netflix.astyanax.thrift;
 
 import com.netflix.astyanax.CassandraOperationTracer;
 import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
 
 public abstract class AbstractKeyspaceOperationImpl<R> extends AbstractOperationImpl<R> {
     private String keyspaceName;
 
-    public AbstractKeyspaceOperationImpl(CassandraOperationTracer tracer, Host pinnedHost, String keyspaceName) {
-        super(tracer, pinnedHost);
+    public AbstractKeyspaceOperationImpl(CassandraOperationTracer tracer, Host pinnedHost, String keyspaceName, ConsistencyLevelPolicy consistencyLevelPolicy) {
+        super(tracer, pinnedHost, consistencyLevelPolicy);
         this.keyspaceName = keyspaceName;
     }
 
-    public AbstractKeyspaceOperationImpl(CassandraOperationTracer tracer, String keyspaceName) {
-        super(tracer);
+    public AbstractKeyspaceOperationImpl(CassandraOperationTracer tracer, String keyspaceName, ConsistencyLevelPolicy consistencyLevelPolicy) {
+        super(tracer, consistencyLevelPolicy);
         this.keyspaceName = keyspaceName;
     }
 

--- a/src/main/java/com/netflix/astyanax/thrift/AbstractOperationImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/AbstractOperationImpl.java
@@ -23,19 +23,23 @@ import com.netflix.astyanax.CassandraOperationTracer;
 import com.netflix.astyanax.connectionpool.Host;
 import com.netflix.astyanax.connectionpool.Operation;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
 
 public abstract class AbstractOperationImpl<R> implements Operation<Cassandra.Client, R> {
     private final CassandraOperationTracer tracer;
     private final Host pinnedHost;
+    protected ConsistencyLevelPolicy consistencyLevelPolicy;
 
-    public AbstractOperationImpl(CassandraOperationTracer tracer, Host host) {
+    public AbstractOperationImpl(CassandraOperationTracer tracer, Host host, ConsistencyLevelPolicy consistencyLevelPolicy) {
         this.tracer = tracer;
         this.pinnedHost = host;
+        this.consistencyLevelPolicy = consistencyLevelPolicy;
     }
 
-    public AbstractOperationImpl(CassandraOperationTracer tracer) {
+    public AbstractOperationImpl(CassandraOperationTracer tracer, ConsistencyLevelPolicy consistencyLevelPolicy) {
         this.tracer = tracer;
         this.pinnedHost = null;
+        this.consistencyLevelPolicy = consistencyLevelPolicy;
     }
 
     @Override
@@ -66,6 +70,25 @@ public abstract class AbstractOperationImpl<R> implements Operation<Cassandra.Cl
     @Override
     public Host getPinnedHost() {
         return pinnedHost;
+    }
+
+    /**
+     * Gets the consistency level policy of this operation.
+     *
+     * @return an object that keeps consistency levels for read and write operations
+     */
+    public ConsistencyLevelPolicy getConsistencyLevelPolicy() {
+        return consistencyLevelPolicy;
+    }
+
+    /**
+     * Set consistency level policy for this operation.
+     *
+     * @param consistencyLevelPolicy object that keeps consistency levels for read and write operations
+     */
+    @Override
+    public void setConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy) {
+        this.consistencyLevelPolicy = consistencyLevelPolicy;
     }
 
     protected abstract R internalExecute(Cassandra.Client client) throws Exception;

--- a/src/main/java/com/netflix/astyanax/thrift/AbstractThriftMutationBatchImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/AbstractThriftMutationBatchImpl.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Maps.EntryTransformer;
 
+import com.netflix.astyanax.consistency.ConsistencyLevelPolicy;
 import org.apache.cassandra.thrift.Cassandra.batch_mutate_args;
 import org.apache.cassandra.thrift.Mutation;
 import org.apache.cassandra.thrift.TBinaryProtocol;
@@ -40,7 +41,6 @@ import com.netflix.astyanax.MutationBatch;
 import com.netflix.astyanax.WriteAheadLog;
 import com.netflix.astyanax.connectionpool.Host;
 import com.netflix.astyanax.model.ColumnFamily;
-import com.netflix.astyanax.model.ConsistencyLevel;
 import com.netflix.astyanax.retry.RetryPolicy;
 import com.netflix.astyanax.serializers.ByteBufferOutputStream;
 
@@ -56,7 +56,7 @@ import com.netflix.astyanax.serializers.ByteBufferOutputStream;
 public abstract class AbstractThriftMutationBatchImpl implements MutationBatch {
 
     protected long timestamp;
-    private ConsistencyLevel consistencyLevel;
+    private ConsistencyLevelPolicy consistencyLevelPolicy;
     private Clock clock;
     private Host pinnedHost;
     private RetryPolicy retry;
@@ -64,10 +64,10 @@ public abstract class AbstractThriftMutationBatchImpl implements MutationBatch {
 
     private Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap = Maps.newLinkedHashMap();
 
-    public AbstractThriftMutationBatchImpl(Clock clock, ConsistencyLevel consistencyLevel, RetryPolicy retry) {
+    public AbstractThriftMutationBatchImpl(Clock clock, ConsistencyLevelPolicy consistencyLevelPolicy, RetryPolicy retry) {
         this.clock = clock;
         this.timestamp = clock.getCurrentTime();
-        this.consistencyLevel = consistencyLevel;
+        this.consistencyLevelPolicy = consistencyLevelPolicy;
         this.retry = retry;
     }
 
@@ -263,19 +263,19 @@ public abstract class AbstractThriftMutationBatchImpl implements MutationBatch {
     }
     
     @Override
-    public MutationBatch setConsistencyLevel(ConsistencyLevel consistencyLevel) {
-        this.consistencyLevel = consistencyLevel;
+    public MutationBatch setConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy) {
+        this.consistencyLevelPolicy = consistencyLevelPolicy;
         return this;
     }
     
     @Override
-    public MutationBatch withConsistencyLevel(ConsistencyLevel consistencyLevel) {
-        this.consistencyLevel = consistencyLevel;
+    public MutationBatch withConsistencyLevelPolicy(ConsistencyLevelPolicy consistencyLevelPolicy) {
+        this.consistencyLevelPolicy = consistencyLevelPolicy;
         return this;
     }
 
-    public ConsistencyLevel getConsistencyLevel() {
-        return this.consistencyLevel;
+    public ConsistencyLevelPolicy getConsistencyLevelPolicy() {
+        return this.consistencyLevelPolicy;
     }
 
     @Override

--- a/src/main/java/com/netflix/astyanax/thrift/ThriftClusterImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/ThriftClusterImpl.java
@@ -65,7 +65,7 @@ public class ThriftClusterImpl implements Cluster {
     @Override
     public String describeClusterName() throws ConnectionException {
         return connectionPool.executeWithFailover(
-                new AbstractOperationImpl<String>(tracerFactory.newTracer(CassandraOperationType.DESCRIBE_CLUSTER)) {
+                new AbstractOperationImpl<String>(tracerFactory.newTracer(CassandraOperationType.DESCRIBE_CLUSTER), config.getDefaultConsistencyLevelPolicy()) {
                     @Override
                     public String internalExecute(Client client) throws Exception {
                         return client.describe_cluster_name();
@@ -77,7 +77,7 @@ public class ThriftClusterImpl implements Cluster {
     @Override
     public String describeSnitch() throws ConnectionException {
         return connectionPool.executeWithFailover(
-                new AbstractOperationImpl<String>(tracerFactory.newTracer(CassandraOperationType.DESCRIBE_SNITCH)) {
+                new AbstractOperationImpl<String>(tracerFactory.newTracer(CassandraOperationType.DESCRIBE_SNITCH), config.getDefaultConsistencyLevelPolicy()) {
                     @Override
                     public String internalExecute(Client client) throws Exception {
                         return client.describe_snitch();
@@ -90,7 +90,7 @@ public class ThriftClusterImpl implements Cluster {
         return connectionPool
                 .executeWithFailover(
                         new AbstractOperationImpl<String>(
-                                tracerFactory.newTracer(CassandraOperationType.DESCRIBE_PARTITIONER)) {
+                                tracerFactory.newTracer(CassandraOperationType.DESCRIBE_PARTITIONER), config.getDefaultConsistencyLevelPolicy()) {
                             @Override
                             public String internalExecute(Client client) throws Exception {
                                 return client.describe_partitioner();
@@ -102,7 +102,7 @@ public class ThriftClusterImpl implements Cluster {
     public Map<String, List<String>> describeSchemaVersions() throws ConnectionException {
         return connectionPool.executeWithFailover(
                 new AbstractOperationImpl<Map<String, List<String>>>(
-                        tracerFactory.newTracer(CassandraOperationType.DESCRIBE_SCHEMA_VERSION)) {
+                        tracerFactory.newTracer(CassandraOperationType.DESCRIBE_SCHEMA_VERSION), config.getDefaultConsistencyLevelPolicy()) {
                     @Override
                     public Map<String, List<String>> internalExecute(Client client) throws Exception {
                         return client.describe_schema_versions();
@@ -119,7 +119,7 @@ public class ThriftClusterImpl implements Cluster {
     @Override
     public String getVersion() throws ConnectionException {
         return connectionPool.executeWithFailover(
-                new AbstractOperationImpl<String>(tracerFactory.newTracer(CassandraOperationType.GET_VERSION)) {
+                new AbstractOperationImpl<String>(tracerFactory.newTracer(CassandraOperationType.GET_VERSION), config.getDefaultConsistencyLevelPolicy()) {
                     @Override
                     public String internalExecute(Client client) throws Exception {
                         return client.describe_version();
@@ -153,7 +153,7 @@ public class ThriftClusterImpl implements Cluster {
     public List<KeyspaceDefinition> describeKeyspaces() throws ConnectionException {
         return connectionPool.executeWithFailover(
                 new AbstractOperationImpl<List<KeyspaceDefinition>>(
-                        tracerFactory.newTracer(CassandraOperationType.DESCRIBE_KEYSPACES)) {
+                        tracerFactory.newTracer(CassandraOperationType.DESCRIBE_KEYSPACES), config.getDefaultConsistencyLevelPolicy()) {
                     @Override
                     public List<KeyspaceDefinition> internalExecute(Client client) throws Exception {
                         List<KsDef> ksDefs = client.describe_keyspaces();
@@ -202,7 +202,7 @@ public class ThriftClusterImpl implements Cluster {
     @Override
     public OperationResult<SchemaChangeResult> addColumnFamily(final ColumnFamilyDefinition def) throws ConnectionException {
         return executeSchemaChangeOperation(new AbstractKeyspaceOperationImpl<SchemaChangeResult>(
-                tracerFactory.newTracer(CassandraOperationType.ADD_COLUMN_FAMILY), def.getKeyspace()) {
+                tracerFactory.newTracer(CassandraOperationType.ADD_COLUMN_FAMILY), def.getKeyspace(), config.getDefaultConsistencyLevelPolicy()) {
             @Override
             public SchemaChangeResult internalExecute(Client client) throws Exception {
                 return new SchemaChangeResponseImpl()
@@ -215,7 +215,7 @@ public class ThriftClusterImpl implements Cluster {
     @Override
     public OperationResult<SchemaChangeResult>  updateColumnFamily(final ColumnFamilyDefinition def) throws ConnectionException {
         return executeSchemaChangeOperation(new AbstractKeyspaceOperationImpl<SchemaChangeResult>(
-                tracerFactory.newTracer(CassandraOperationType.UPDATE_COLUMN_FAMILY), def.getKeyspace()) {
+                tracerFactory.newTracer(CassandraOperationType.UPDATE_COLUMN_FAMILY), def.getKeyspace(), config.getDefaultConsistencyLevelPolicy()) {
             @Override
             public SchemaChangeResult internalExecute(Client client) throws Exception {
                 return new SchemaChangeResponseImpl()
@@ -233,7 +233,7 @@ public class ThriftClusterImpl implements Cluster {
     @Override
     public OperationResult<SchemaChangeResult>  addKeyspace(final KeyspaceDefinition def) throws ConnectionException {
         return executeSchemaChangeOperation(new AbstractOperationImpl<SchemaChangeResult>(
-                tracerFactory.newTracer(CassandraOperationType.ADD_KEYSPACE)) {
+                tracerFactory.newTracer(CassandraOperationType.ADD_KEYSPACE), config.getDefaultConsistencyLevelPolicy()) {
             @Override
             public SchemaChangeResult internalExecute(Client client) throws Exception {
                 return new SchemaChangeResponseImpl()
@@ -245,7 +245,7 @@ public class ThriftClusterImpl implements Cluster {
     @Override
     public OperationResult<SchemaChangeResult>  updateKeyspace(final KeyspaceDefinition def) throws ConnectionException {
         return executeSchemaChangeOperation(new AbstractOperationImpl<SchemaChangeResult>(
-                tracerFactory.newTracer(CassandraOperationType.UPDATE_KEYSPACE)) {
+                tracerFactory.newTracer(CassandraOperationType.UPDATE_KEYSPACE), config.getDefaultConsistencyLevelPolicy()) {
             @Override
             public SchemaChangeResult internalExecute(Client client) throws Exception {
                 return new SchemaChangeResponseImpl()
@@ -270,7 +270,8 @@ public class ThriftClusterImpl implements Cluster {
         return connectionPool
                 .executeWithFailover(
                         new AbstractKeyspaceOperationImpl<SchemaChangeResult>(
-                                tracerFactory.newTracer(CassandraOperationType.ADD_COLUMN_FAMILY), (String)options.get("keyspace")) {
+                                tracerFactory.newTracer(CassandraOperationType.ADD_COLUMN_FAMILY), (String)options.get("keyspace"),
+                                config.getDefaultConsistencyLevelPolicy()) {
                             @Override
                             public SchemaChangeResult internalExecute(Client client) throws Exception {
                                 ThriftColumnFamilyDefinitionImpl def = new ThriftColumnFamilyDefinitionImpl();
@@ -287,7 +288,8 @@ public class ThriftClusterImpl implements Cluster {
         return connectionPool
                 .executeWithFailover(
                         new AbstractKeyspaceOperationImpl<SchemaChangeResult>(
-                                tracerFactory.newTracer(CassandraOperationType.UPDATE_COLUMN_FAMILY), (String)options.get("keyspace")) {
+                                tracerFactory.newTracer(CassandraOperationType.UPDATE_COLUMN_FAMILY), (String)options.get("keyspace"),
+                                config.getDefaultConsistencyLevelPolicy()) {
                             @Override
                             public SchemaChangeResult internalExecute(Client client) throws Exception {
                                 ThriftColumnFamilyDefinitionImpl def = new ThriftColumnFamilyDefinitionImpl();
@@ -304,7 +306,8 @@ public class ThriftClusterImpl implements Cluster {
         return connectionPool
                 .executeWithFailover(
                         new AbstractKeyspaceOperationImpl<SchemaChangeResult>(
-                                tracerFactory.newTracer(CassandraOperationType.DROP_COLUMN_FAMILY), keyspaceName) {
+                                tracerFactory.newTracer(CassandraOperationType.DROP_COLUMN_FAMILY), keyspaceName,
+                                config.getDefaultConsistencyLevelPolicy()) {
                             @Override
                             public SchemaChangeResult internalExecute(Client client) throws Exception {
                                 return new SchemaChangeResponseImpl()
@@ -318,7 +321,8 @@ public class ThriftClusterImpl implements Cluster {
         return connectionPool
                 .executeWithFailover(
                         new AbstractOperationImpl<SchemaChangeResult>(
-                                tracerFactory.newTracer(CassandraOperationType.ADD_KEYSPACE)) {
+                                tracerFactory.newTracer(CassandraOperationType.ADD_KEYSPACE),
+                                config.getDefaultConsistencyLevelPolicy()) {
                             @Override
                             public SchemaChangeResult internalExecute(Client client) throws Exception {
                                 ThriftKeyspaceDefinitionImpl def = new ThriftKeyspaceDefinitionImpl();
@@ -335,7 +339,8 @@ public class ThriftClusterImpl implements Cluster {
         return connectionPool
                 .executeWithFailover(
                         new AbstractKeyspaceOperationImpl<SchemaChangeResult>(
-                                tracerFactory.newTracer(CassandraOperationType.UPDATE_KEYSPACE), (String)options.get("name")) {
+                                tracerFactory.newTracer(CassandraOperationType.UPDATE_KEYSPACE), (String)options.get("name"),
+                                config.getDefaultConsistencyLevelPolicy()) {
                             @Override
                             public SchemaChangeResult internalExecute(Client client) throws Exception {
                                 ThriftKeyspaceDefinitionImpl def = new ThriftKeyspaceDefinitionImpl();
@@ -352,7 +357,8 @@ public class ThriftClusterImpl implements Cluster {
         return connectionPool
                 .executeWithFailover(
                         new AbstractKeyspaceOperationImpl<SchemaChangeResult>(
-                                tracerFactory.newTracer(CassandraOperationType.DROP_KEYSPACE), keyspaceName) {
+                                tracerFactory.newTracer(CassandraOperationType.DROP_KEYSPACE), keyspaceName,
+                                config.getDefaultConsistencyLevelPolicy()) {
                             @Override
                             public SchemaChangeResult internalExecute(Client client) throws Exception {
                                 return new SchemaChangeResponseImpl()

--- a/src/test/java/com/netflix/astyanax/connectionpool/impl/HostConnectionPoolPartitionTest.java
+++ b/src/test/java/com/netflix/astyanax/connectionpool/impl/HostConnectionPoolPartitionTest.java
@@ -2,16 +2,13 @@ package com.netflix.astyanax.connectionpool.impl;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import junit.framework.Assert;
 
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.netflix.astyanax.connectionpool.Host;
 import com.netflix.astyanax.connectionpool.HostConnectionPool;
 import com.netflix.astyanax.connectionpool.LatencyScoreStrategy;

--- a/src/test/java/com/netflix/astyanax/recipes/UniquenessConstraintTest.java
+++ b/src/test/java/com/netflix/astyanax/recipes/UniquenessConstraintTest.java
@@ -3,6 +3,7 @@ package com.netflix.astyanax.recipes;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.netflix.astyanax.consistency.OneOneConsistencyLevelPolicy;
 import junit.framework.Assert;
 
 import org.junit.AfterClass;
@@ -22,7 +23,6 @@ import com.netflix.astyanax.connectionpool.impl.CountingConnectionPoolMonitor;
 import com.netflix.astyanax.ddl.KeyspaceDefinition;
 import com.netflix.astyanax.impl.AstyanaxConfigurationImpl;
 import com.netflix.astyanax.model.ColumnFamily;
-import com.netflix.astyanax.model.ConsistencyLevel;
 import com.netflix.astyanax.serializers.LongSerializer;
 import com.netflix.astyanax.serializers.StringSerializer;
 import com.netflix.astyanax.thrift.ThriftFamilyFactory;
@@ -111,7 +111,7 @@ public class UniquenessConstraintTest {
                 keyspace, CF_DATA)
                 .setTtl(2)
                 .setPrefix("unique_")
-                .setConsistencyLevel(ConsistencyLevel.CL_ONE)
+                .setConsistencyLevelPolicy(OneOneConsistencyLevelPolicy.get())
                 .setMonitor(
                         new UniquenessConstraintViolationMonitor<Long, String>() {
                             @Override

--- a/src/test/java/com/netflix/astyanax/thrift/ThrifeKeyspaceImplTest.java
+++ b/src/test/java/com/netflix/astyanax/thrift/ThrifeKeyspaceImplTest.java
@@ -12,6 +12,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.netflix.astyanax.consistency.OneOneConsistencyLevelPolicy;
+import com.netflix.astyanax.consistency.QuorumQuorumConsistencyLevelPolicy;
 import junit.framework.Assert;
 
 import org.apache.cassandra.utils.Pair;
@@ -475,13 +477,13 @@ public class ThrifeKeyspaceImplTest {
     public void testMultiRowUniqueness() {
         DedicatedMultiRowUniquenessConstraint<UUID> constraint = new DedicatedMultiRowUniquenessConstraint<UUID>
                   (keyspace, TimeUUIDUtils.getUniqueTimeUUIDinMicros())
-                  .withConsistencyLevel(ConsistencyLevel.CL_ONE)
+                  .withConsistencyLevelPolicy(OneOneConsistencyLevelPolicy.get())
                   .withRow(CF_USER_UNIQUE_UUID, "user1")
                   .withRow(CF_EMAIL_UNIQUE_UUID, "user1@domain.com");
         
         DedicatedMultiRowUniquenessConstraint<UUID> constraint2 = new DedicatedMultiRowUniquenessConstraint<UUID>
                   (keyspace, TimeUUIDUtils.getUniqueTimeUUIDinMicros())
-                  .withConsistencyLevel(ConsistencyLevel.CL_ONE)
+                  .withConsistencyLevelPolicy(OneOneConsistencyLevelPolicy.get())
                   .withRow(CF_USER_UNIQUE_UUID, "user1")
                   .withRow(CF_EMAIL_UNIQUE_UUID, "user1@domain.com");
         
@@ -1148,7 +1150,7 @@ public class ThrifeKeyspaceImplTest {
     public void testChangeConsistencyLevel() {
         try {
             keyspace.prepareQuery(CF_STANDARD1)
-                    .setConsistencyLevel(ConsistencyLevel.CL_ONE).getKey("A")
+                    .setConsistencyLevelPolicy(OneOneConsistencyLevelPolicy.get()).getKey("A")
                     .execute();
         } catch (ConnectionException e) {
             Assert.fail(e.getMessage());
@@ -1905,7 +1907,7 @@ public class ThrifeKeyspaceImplTest {
         // Verify count
         try {
             int count = keyspace.prepareQuery(CF_STANDARD1)
-                    .setConsistencyLevel(ConsistencyLevel.CL_QUORUM)
+                    .setConsistencyLevelPolicy(QuorumQuorumConsistencyLevelPolicy.get())
                     .getKey(rowKey).getCount().execute().getResult();
             Assert.assertEquals(nColumns, count);
         } catch (ConnectionException e) {
@@ -1913,8 +1915,8 @@ public class ThrifeKeyspaceImplTest {
         }
 
         // Delete half of the columns
-        m = keyspace.prepareMutationBatch().setConsistencyLevel(
-                ConsistencyLevel.CL_QUORUM);
+        m = keyspace.prepareMutationBatch().setConsistencyLevelPolicy(
+                QuorumQuorumConsistencyLevelPolicy.get());
         rm = m.withRow(CF_STANDARD1, rowKey);
 
         for (int i = 0; i < nColumns / 2; i++) {
@@ -1941,8 +1943,8 @@ public class ThrifeKeyspaceImplTest {
         }
 
         // Delete all of the columns
-        m = keyspace.prepareMutationBatch().setConsistencyLevel(
-                ConsistencyLevel.CL_QUORUM);
+        m = keyspace.prepareMutationBatch().setConsistencyLevelPolicy(
+                QuorumQuorumConsistencyLevelPolicy.get());
         rm = m.withRow(CF_STANDARD1, rowKey);
 
         for (int i = 0; i < nColumns; i++) {
@@ -1973,7 +1975,7 @@ public class ThrifeKeyspaceImplTest {
     private <K, C> int getRowColumnCount(ColumnFamily<K, C> cf, K rowKey)
             throws ConnectionException {
         int count = keyspace.prepareQuery(cf)
-                .setConsistencyLevel(ConsistencyLevel.CL_QUORUM).getKey(rowKey)
+                .setConsistencyLevelPolicy(QuorumQuorumConsistencyLevelPolicy.get()).getKey(rowKey)
                 .getCount().execute().getResult();
 
         return count;
@@ -1982,7 +1984,7 @@ public class ThrifeKeyspaceImplTest {
     private <K, C> int getRowColumnCountWithPagination(ColumnFamily<K, C> cf,
             K rowKey, int pageSize) throws ConnectionException {
         RowQuery<K, C> query = keyspace.prepareQuery(cf)
-                .setConsistencyLevel(ConsistencyLevel.CL_QUORUM).getKey(rowKey)
+                .setConsistencyLevelPolicy(QuorumQuorumConsistencyLevelPolicy.get()).getKey(rowKey)
                 .withColumnRange(new RangeBuilder().setLimit(pageSize).build())
                 .autoPaginate(true);
 


### PR DESCRIPTION
It would be good to provide on-the fly consistency level switching on the operation level to improve data availability. Can be helpful when the replication factor 2 is used.
http://www.mail-archive.com/user@cassandra.apache.org/msg24740.html
