### PR TITLE
Options for working with the local data center has been added

### DIFF
--- a/src/main/java/com/netflix/astyanax/AstyanaxContext.java
+++ b/src/main/java/com/netflix/astyanax/AstyanaxContext.java
@@ -147,15 +147,15 @@ public class AstyanaxContext<Entity> {
                 break;
 
             case RING_DESCRIBE:
-                supplier = new RingDescribeHostSupplier(keyspace, cpConfig.getPort());
+                supplier = new RingDescribeHostSupplier(keyspace, cpConfig.getPort(), cpConfig.getLocalDatacenter());
                 break;
 
             case TOKEN_AWARE:
                 if (hostSupplier == null) {
-                    supplier = new RingDescribeHostSupplier(keyspace, cpConfig.getPort());
+                    supplier = new RingDescribeHostSupplier(keyspace, cpConfig.getPort(), cpConfig.getLocalDatacenter());
                 }
                 else {
-                    supplier = new FilteringHostSupplier(new RingDescribeHostSupplier(keyspace, cpConfig.getPort()),
+                    supplier = new FilteringHostSupplier(new RingDescribeHostSupplier(keyspace, cpConfig.getPort(), cpConfig.getLocalDatacenter()),
                             hostSupplier);
                 }
                 break;

--- a/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolConfiguration.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolConfiguration.java
@@ -114,6 +114,13 @@ public interface ConnectionPoolConfiguration {
     List<Host> getSeedHosts();
 
     /**
+     * Return local datacenter name.
+     * 
+     * @return
+     */
+    public String getLocalDatacenter();
+
+    /**
      * Socket read/write timeout
      * 
      * @return

--- a/src/main/java/com/netflix/astyanax/connectionpool/impl/ConnectionPoolConfigurationImpl.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/impl/ConnectionPoolConfigurationImpl.java
@@ -101,6 +101,8 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
     private OperationFilterFactory filterFactory          = EmptyOperationFilterFactory.getInstance();
     private Partitioner partitioner                       = DEFAULT_PARTITIONER;
 
+    private String localDatacenter = null;
+    
     public ConnectionPoolConfigurationImpl(String name) {
         this.name = name;
         this.badHostDetector = new BadHostDetectorImpl(this);
@@ -160,6 +162,20 @@ public class ConnectionPoolConfigurationImpl implements ConnectionPoolConfigurat
 
     public ConnectionPoolConfigurationImpl setSeeds(String seeds) {
         this.seeds = seeds;
+        return this;
+    }
+
+    /**
+     * Returns local datacenter name
+     *
+     * @return
+     */
+    public String getLocalDatacenter() {
+        return localDatacenter;
+    }
+
+    public ConnectionPoolConfigurationImpl setLocalDatacenter(String localDatacenter) {
+        this.localDatacenter = localDatacenter;
         return this;
     }
 


### PR DESCRIPTION
When you specify the local data center name the client will send requests only to the hosts in the local data center.
