### PR TITLE
Preprocessing option has been added to the Operation interface to allow changing the operation's consistency level before execution.

### DIFF
--- a/src/main/java/com/netflix/astyanax/connectionpool/Operation.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/Operation.java
@@ -60,8 +60,14 @@ public interface Operation<CL, R> {
      * Return the host to run on or null to select a host using the load
      * blancer. Failover is disabled for this scenario.
      * 
-     * @param host
-     * @return
+     * @return host
      */
     Host getPinnedHost();
+
+    /**
+     * Performs some actions before the command execution
+     * 
+     * @param preprocessor the object that exposes some available actions to perform
+     */
+    void preprocess(OperationPreprocessor preprocessor);
 }

--- a/src/main/java/com/netflix/astyanax/connectionpool/OperationPreprocessor.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/OperationPreprocessor.java
@@ -1,0 +1,12 @@
+package com.netflix.astyanax.connectionpool;
+
+import com.netflix.astyanax.consistency.ReadConsistencyLevelProvider;
+import com.netflix.astyanax.consistency.WriteConsistencyLevelProvider;
+
+/**
+ * @author Max Morozov
+ */
+public interface OperationPreprocessor {
+    void handleReadConsistency(ReadConsistencyLevelProvider provider);
+    void handleWriteConsistency(WriteConsistencyLevelProvider provider);
+}

--- a/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractOperationFilter.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractOperationFilter.java
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer;
 
 import com.netflix.astyanax.connectionpool.Host;
 import com.netflix.astyanax.connectionpool.Operation;
+import com.netflix.astyanax.connectionpool.OperationPreprocessor;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 
 public class AbstractOperationFilter<R, CL> implements Operation<R, CL>{
@@ -32,6 +33,10 @@ public class AbstractOperationFilter<R, CL> implements Operation<R, CL>{
     @Override
     public Host getPinnedHost() {
         return next.getPinnedHost();
+    }
+
+    @Override
+    public void preprocess(OperationPreprocessor preprocessor) {
     }
 
 }

--- a/src/main/java/com/netflix/astyanax/connectionpool/impl/HostConnectionPoolPartition.java
+++ b/src/main/java/com/netflix/astyanax/connectionpool/impl/HostConnectionPoolPartition.java
@@ -94,6 +94,10 @@ public class HostConnectionPoolPartition<CL> {
     public List<HostConnectionPool<CL>> getPools() {
         return activePools.get();
     }
+
+    public Set<HostConnectionPool<CL>> getAllPools() {
+        return this.pools;
+    }
     
     /**
      * If true the the hosts are sorted by order of priority where the 

--- a/src/main/java/com/netflix/astyanax/consistency/ReadConsistencyLevelProvider.java
+++ b/src/main/java/com/netflix/astyanax/consistency/ReadConsistencyLevelProvider.java
@@ -1,0 +1,22 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+/**
+ * @author Max Morozov
+ */
+public interface ReadConsistencyLevelProvider {
+    /**
+     * Gets read consistency level of this operation.
+     *
+     * @return operation's read consistency level
+     */
+    ConsistencyLevel getReadConsistencyLevel();
+
+    /**
+     * Set read consistency level of this operation.
+     *
+     * @param consistencyLevel new read consistency level
+     */
+    void setReadConsistencyLevel(ConsistencyLevel consistencyLevel);
+}

--- a/src/main/java/com/netflix/astyanax/consistency/WriteConsistencyLevelProvider.java
+++ b/src/main/java/com/netflix/astyanax/consistency/WriteConsistencyLevelProvider.java
@@ -1,0 +1,22 @@
+package com.netflix.astyanax.consistency;
+
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+/**
+ * @author Max Morozov
+ */
+public interface WriteConsistencyLevelProvider {
+    /**
+     * Gets write consistency level of this operation.
+     *
+     * @return operation's write consistency level
+     */
+    ConsistencyLevel getWriteConsistencyLevel();
+
+    /**
+     * Set write consistency level of this operation.
+     *
+     * @param consistencyLevel new write consistency level
+     */
+    void setWriteConsistencyLevel(ConsistencyLevel consistencyLevel);
+}

--- a/src/main/java/com/netflix/astyanax/test/TestOperation.java
+++ b/src/main/java/com/netflix/astyanax/test/TestOperation.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 
 import com.netflix.astyanax.connectionpool.Host;
 import com.netflix.astyanax.connectionpool.Operation;
+import com.netflix.astyanax.connectionpool.OperationPreprocessor;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.netflix.astyanax.connectionpool.exceptions.OperationException;
 
@@ -42,5 +43,14 @@ public class TestOperation implements Operation<TestClient, String> {
     @Override
     public Host getPinnedHost() {
         return null;
+    }
+
+    /**
+     * Performs some actions before the command execution
+     *
+     * @param preprocessor the object that exposes some available actions to perform
+     */
+    @Override
+    public void preprocess(OperationPreprocessor preprocessor) {
     }
 }

--- a/src/main/java/com/netflix/astyanax/thrift/AbstractOperationImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/AbstractOperationImpl.java
@@ -17,6 +17,7 @@ package com.netflix.astyanax.thrift;
 
 import java.nio.ByteBuffer;
 
+import com.netflix.astyanax.connectionpool.OperationPreprocessor;
 import org.apache.cassandra.thrift.Cassandra;
 
 import com.netflix.astyanax.CassandraOperationTracer;
@@ -69,4 +70,8 @@ public abstract class AbstractOperationImpl<R> implements Operation<Cassandra.Cl
     }
 
     protected abstract R internalExecute(Cassandra.Client client) throws Exception;
+
+    @Override
+    public void preprocess(OperationPreprocessor preprocessor) {
+    }
 }

--- a/src/main/java/com/netflix/astyanax/thrift/AbstractReadOperationImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/AbstractReadOperationImpl.java
@@ -1,0 +1,40 @@
+package com.netflix.astyanax.thrift;
+
+import com.netflix.astyanax.CassandraOperationTracer;
+import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.astyanax.connectionpool.OperationPreprocessor;
+import com.netflix.astyanax.consistency.ReadConsistencyLevelProvider;
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+/**
+ * @author Max Morozov
+ */
+public abstract class AbstractReadOperationImpl<R> extends AbstractKeyspaceOperationImpl<R> implements ReadConsistencyLevelProvider {
+    private ConsistencyLevel consistencyLevel;
+    
+    public AbstractReadOperationImpl(CassandraOperationTracer tracer, Host pinnedHost, String keyspaceName, ConsistencyLevel consistencyLevel) {
+        super(tracer, pinnedHost, keyspaceName);
+        this.consistencyLevel = consistencyLevel;
+    }
+
+    public AbstractReadOperationImpl(CassandraOperationTracer tracer, String keyspaceName, ConsistencyLevel consistencyLevel) {
+        super(tracer, keyspaceName);
+        this.consistencyLevel = consistencyLevel;
+    }
+
+    @Override
+    public ConsistencyLevel getReadConsistencyLevel() {
+        return consistencyLevel;
+    }
+
+    @Override
+    public void setReadConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        this.consistencyLevel = consistencyLevel;
+    }
+
+    @Override
+    public void preprocess(OperationPreprocessor preprocessor) {
+        preprocessor.handleReadConsistency(this);
+    }
+
+}

--- a/src/main/java/com/netflix/astyanax/thrift/AbstractReadWriteOperationImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/AbstractReadWriteOperationImpl.java
@@ -1,0 +1,58 @@
+package com.netflix.astyanax.thrift;
+
+import com.netflix.astyanax.CassandraOperationTracer;
+import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.astyanax.connectionpool.OperationPreprocessor;
+import com.netflix.astyanax.consistency.ReadConsistencyLevelProvider;
+import com.netflix.astyanax.consistency.WriteConsistencyLevelProvider;
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+/**
+ * @author Max Morozov
+ */
+public abstract class AbstractReadWriteOperationImpl<R> extends AbstractKeyspaceOperationImpl<R> 
+        implements ReadConsistencyLevelProvider, WriteConsistencyLevelProvider {
+    private ConsistencyLevel readConsistencyLevel;
+    private ConsistencyLevel writeConsistencyLevel;
+
+    public AbstractReadWriteOperationImpl(CassandraOperationTracer tracer, Host pinnedHost, String keyspaceName, 
+                                          ConsistencyLevel readConsistencyLevel, ConsistencyLevel writeConsistencyLevel) {
+        super(tracer, pinnedHost, keyspaceName);
+        this.readConsistencyLevel = readConsistencyLevel;
+        this.writeConsistencyLevel = writeConsistencyLevel;
+    }
+
+    public AbstractReadWriteOperationImpl(CassandraOperationTracer tracer, String keyspaceName, 
+                                          ConsistencyLevel readConsistencyLevel, ConsistencyLevel writeConsistencyLevel) {
+        super(tracer, keyspaceName);
+        this.readConsistencyLevel = readConsistencyLevel;
+        this.writeConsistencyLevel = writeConsistencyLevel;
+    }
+
+    @Override
+    public ConsistencyLevel getReadConsistencyLevel() {
+        return readConsistencyLevel;
+    }
+
+    @Override
+    public ConsistencyLevel getWriteConsistencyLevel() {
+        return writeConsistencyLevel;
+    }
+
+    @Override
+    public void setReadConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        this.readConsistencyLevel = consistencyLevel;
+    }
+
+    @Override
+    public void setWriteConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        this.writeConsistencyLevel = consistencyLevel;
+    }
+
+    @Override
+    public void preprocess(OperationPreprocessor preprocessor) {
+        preprocessor.handleReadConsistency(this);
+        preprocessor.handleWriteConsistency(this);
+    }
+
+}

--- a/src/main/java/com/netflix/astyanax/thrift/AbstractWriteOperationImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/AbstractWriteOperationImpl.java
@@ -1,0 +1,40 @@
+package com.netflix.astyanax.thrift;
+
+import com.netflix.astyanax.CassandraOperationTracer;
+import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.astyanax.connectionpool.OperationPreprocessor;
+import com.netflix.astyanax.consistency.WriteConsistencyLevelProvider;
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+/**
+ * @author Max Morozov
+ */
+public abstract class AbstractWriteOperationImpl<R> extends AbstractKeyspaceOperationImpl<R>  implements WriteConsistencyLevelProvider {
+    private ConsistencyLevel consistencyLevel;
+
+    public AbstractWriteOperationImpl(CassandraOperationTracer tracer, Host pinnedHost, String keyspaceName, ConsistencyLevel consistencyLevel) {
+        super(tracer, pinnedHost, keyspaceName);
+        this.consistencyLevel = consistencyLevel;
+    }
+
+    public AbstractWriteOperationImpl(CassandraOperationTracer tracer, String keyspaceName, ConsistencyLevel consistencyLevel) {
+        super(tracer, keyspaceName);
+        this.consistencyLevel = consistencyLevel;
+    }
+
+    @Override
+    public ConsistencyLevel getWriteConsistencyLevel() {
+        return consistencyLevel;
+    }
+
+    @Override
+    public void setWriteConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        this.consistencyLevel = consistencyLevel;
+    }
+
+    @Override
+    public void preprocess(OperationPreprocessor preprocessor) {
+        preprocessor.handleWriteConsistency(this);
+    }
+
+}

--- a/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
@@ -97,13 +97,13 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                 }
                 try {
                     OperationResult<Void> result = executeOperation(
-                            new AbstractKeyspaceOperationImpl<Void>(
+                            new AbstractWriteOperationImpl<Void>(
                                     tracerFactory.newTracer(CassandraOperationType.BATCH_MUTATE), getPinnedHost(),
-                                    getKeyspaceName()) {
+                                    getKeyspaceName(), getConsistencyLevel()) {
                                 @Override
                                 public Void internalExecute(Client client) throws Exception {
                                     client.batch_mutate(getMutationMap(),
-                                            ThriftConverter.ToThriftConsistencyLevel(getConsistencyLevel()));
+                                            ThriftConverter.ToThriftConsistencyLevel(getWriteConsistencyLevel()));
                                     discardMutations();
                                     return null;
                                 }
@@ -244,14 +244,14 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                     @Override
                     public OperationResult<Void> execute() throws ConnectionException {
                         return executeOperation(
-                                new AbstractKeyspaceOperationImpl<Void>(
+                                new AbstractWriteOperationImpl<Void>(
                                         tracerFactory.newTracer(CassandraOperationType.COUNTER_MUTATE),
-                                        getKeyspaceName()) {
+                                        getKeyspaceName(), writeConsistencyLevel) {
                                     @Override
                                     public Void internalExecute(Client client) throws Exception {
                                         client.add(key, ThriftConverter.getColumnParent(columnFamily, null),
                                                 new CounterColumn().setValue(amount).setName(column),
-                                                ThriftConverter.ToThriftConsistencyLevel(writeConsistencyLevel));
+                                                ThriftConverter.ToThriftConsistencyLevel(getWriteConsistencyLevel()));
                                         return null;
                                     }
 
@@ -281,15 +281,15 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                     @Override
                     public OperationResult<Void> execute() throws ConnectionException {
                         return executeOperation(
-                                new AbstractKeyspaceOperationImpl<Void>(
+                                new AbstractWriteOperationImpl<Void>(
                                         tracerFactory.newTracer(CassandraOperationType.COLUMN_DELETE),
-                                        getKeyspaceName()) {
+                                        getKeyspaceName(), writeConsistencyLevel) {
                                     @Override
                                     public Void internalExecute(Client client) throws Exception {
                                         client.remove(key, new org.apache.cassandra.thrift.ColumnPath()
                                                 .setColumn_family(columnFamily.getName()).setColumn(column), config
                                                 .getClock().getCurrentTime(), ThriftConverter
-                                                .ToThriftConsistencyLevel(writeConsistencyLevel));
+                                                .ToThriftConsistencyLevel(getWriteConsistencyLevel()));
                                         return null;
                                     }
 
@@ -318,9 +318,9 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                     @Override
                     public OperationResult<Void> execute() throws ConnectionException {
                         return executeOperation(
-                                new AbstractKeyspaceOperationImpl<Void>(
+                                new AbstractWriteOperationImpl<Void>(
                                         tracerFactory.newTracer(CassandraOperationType.COLUMN_INSERT),
-                                        getKeyspaceName()) {
+                                        getKeyspaceName(), writeConsistencyLevel) {
                                     @Override
                                     public Void internalExecute(Client client) throws Exception {
                                         org.apache.cassandra.thrift.Column c = new org.apache.cassandra.thrift.Column();
@@ -330,7 +330,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                         }
 
                                         client.insert(key, ThriftConverter.getColumnParent(columnFamily, null), c,
-                                                ThriftConverter.ToThriftConsistencyLevel(writeConsistencyLevel));
+                                                ThriftConverter.ToThriftConsistencyLevel(getWriteConsistencyLevel()));
                                         return null;
                                     }
 
@@ -359,14 +359,14 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                     @Override
                     public OperationResult<Void> execute() throws ConnectionException {
                         return executeOperation(
-                                new AbstractKeyspaceOperationImpl<Void>(
+                                new AbstractWriteOperationImpl<Void>(
                                         tracerFactory.newTracer(CassandraOperationType.COLUMN_DELETE),
-                                        getKeyspaceName()) {
+                                        getKeyspaceName(), writeConsistencyLevel) {
                                     @Override
                                     public Void internalExecute(Client client) throws Exception {
                                         client.remove_counter(key, new org.apache.cassandra.thrift.ColumnPath()
                                                 .setColumn_family(columnFamily.getName()).setColumn(column),
-                                                ThriftConverter.ToThriftConsistencyLevel(writeConsistencyLevel));
+                                                ThriftConverter.ToThriftConsistencyLevel(getWriteConsistencyLevel()));
                                         return null;
                                     }
 


### PR DESCRIPTION
Current implementation allows to change consistency level dynamically. This mechanism can be extended to support different options.
If you use replication factor 2, and consistency level LOCAL_QUORUM, write requests will fail if one of the replica servers is down. if you use replication factor 3 this situation is not critical. To solve the problem we change the consistency level dynamically.
