### PR TITLE
Use ListenableFuture instead of Java Future

### DIFF
--- a/src/main/java/com/netflix/astyanax/Execution.java
+++ b/src/main/java/com/netflix/astyanax/Execution.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 Netflix
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,19 +18,19 @@ package com.netflix.astyanax;
 import com.netflix.astyanax.connectionpool.OperationResult;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 
-import java.util.concurrent.Future;
+import com.google.common.util.concurrent.ListenableFuture;
 
 /**
  * Interface for an operation that can be executed on the cluster.
- * 
+ *
  * @author elandau
- * 
+ *
  * @param <R>
  */
 public interface Execution<R> {
     /**
      * Block while executing the operations
-     * 
+     *
      * @return
      * @throws ConnectionException
      */
@@ -40,9 +40,9 @@ public interface Execution<R> {
      * Return a future to the operation. The operation will most likely be
      * executed in a separate thread where both the connection pool logic as
      * well as the actual operation will be executed.
-     * 
+     *
      * @return
      * @throws ConnectionException
      */
-    Future<OperationResult<R>> executeAsync() throws ConnectionException;
+    ListenableFuture<OperationResult<R>> executeAsync() throws ConnectionException;
 }

--- a/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 Netflix
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.cassandra.thrift.Cassandra;
@@ -34,6 +33,9 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.netflix.astyanax.AstyanaxConfiguration;
 import com.netflix.astyanax.ColumnMutation;
 import com.netflix.astyanax.Execution;
@@ -69,16 +71,16 @@ public final class ThriftKeyspaceImpl implements Keyspace {
     private final ConnectionPool<Cassandra.Client> connectionPool;
     private final AstyanaxConfiguration config;
     private final String                ksName;
-    private final ExecutorService       executor;
+    private final ListeningExecutorService executor;
     private final KeyspaceTracerFactory tracerFactory;
     private final Cache<String, Object> cache;
-    
+
     public ThriftKeyspaceImpl(String ksName, ConnectionPool<Cassandra.Client> pool, AstyanaxConfiguration config,
             final KeyspaceTracerFactory tracerFactory) {
         this.connectionPool = pool;
         this.config         = config;
         this.ksName         = ksName;
-        this.executor       = config.getAsyncExecutor();
+        this.executor       = MoreExecutors.listeningDecorator(config.getAsyncExecutor());
         this.tracerFactory  = tracerFactory;
         this.cache          = CacheBuilder.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).build();
     }
@@ -135,7 +137,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
             }
 
             @Override
-            public Future<OperationResult<Void>> executeAsync() throws ConnectionException {
+            public ListenableFuture<OperationResult<Void>> executeAsync() throws ConnectionException {
                 return executor.submit(new Callable<OperationResult<Void>>() {
                     @Override
                     public OperationResult<Void> call() throws Exception {
@@ -150,12 +152,12 @@ public final class ThriftKeyspaceImpl implements Keyspace {
     public List<TokenRange> describeRing() throws ConnectionException {
         return describeRing(null, null);
     }
-    
+
     @Override
     public List<TokenRange> describeRing(final String dc) throws ConnectionException {
         return describeRing(dc, null);
     }
-    
+
     @Override
     public List<TokenRange> describeRing(final String dc, final String rack) throws ConnectionException {
         return executeOperation(
@@ -165,7 +167,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                     public List<TokenRange> internalExecute(Cassandra.Client client, ConnectionContext context) throws Exception {
                         List<org.apache.cassandra.thrift.TokenRange> trs = client.describe_ring(getKeyspaceName());
                         List<TokenRange> range = Lists.newArrayList();
-                        
+
                         for (org.apache.cassandra.thrift.TokenRange tr : trs) {
                             List<String> endpoints = Lists.newArrayList();
                             for (org.apache.cassandra.thrift.EndpointDetails ed : tr.getEndpoint_details()) {
@@ -179,7 +181,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                     endpoints.add(ed.getHost());
                                 }
                             }
-                            
+
                             if (!endpoints.isEmpty()) {
                                 range.add(new TokenRangeImpl(tr.getStart_token(), tr.getEnd_token(), endpoints));
                             }
@@ -210,7 +212,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
             return describeRing();
         }
     }
-    
+
     @Override
     public KeyspaceDefinition describeKeyspace() throws ConnectionException {
         return executeOperation(
@@ -237,20 +239,20 @@ public final class ThriftKeyspaceImpl implements Keyspace {
 
     public <K, C> ColumnFamilyQuery<K, C> prepareQuery(ColumnFamily<K, C> cf) {
         return new ThriftColumnFamilyQueryImpl<K, C>(
-                executor, 
-                tracerFactory, 
-                this, 
-                connectionPool, 
+                executor,
+                tracerFactory,
+                this,
+                connectionPool,
                 cf,
-                config.getDefaultReadConsistencyLevel(), 
+                config.getDefaultReadConsistencyLevel(),
                 config.getRetryPolicy());
     }
 
     @Override
     public <K, C> ColumnMutation prepareColumnMutation(final ColumnFamily<K, C> columnFamily, final K rowKey, C column) {
         return new AbstractThriftColumnMutationImpl(
-                columnFamily.getKeySerializer().toByteBuffer(rowKey), 
-                columnFamily.getColumnSerializer().toByteBuffer(column), 
+                columnFamily.getKeySerializer().toByteBuffer(rowKey),
+                columnFamily.getColumnSerializer().toByteBuffer(column),
                 config) {
 
             @Override
@@ -279,7 +281,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                     }
 
                     @Override
-                    public Future<OperationResult<Void>> executeAsync() throws ConnectionException {
+                    public ListenableFuture<OperationResult<Void>> executeAsync() throws ConnectionException {
                         return executor.submit(new Callable<OperationResult<Void>>() {
                             @Override
                             public OperationResult<Void> call() throws Exception {
@@ -316,7 +318,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                     }
 
                     @Override
-                    public Future<OperationResult<Void>> executeAsync() throws ConnectionException {
+                    public ListenableFuture<OperationResult<Void>> executeAsync() throws ConnectionException {
                         return executor.submit(new Callable<OperationResult<Void>>() {
                             @Override
                             public OperationResult<Void> call() throws Exception {
@@ -357,7 +359,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                     }
 
                     @Override
-                    public Future<OperationResult<Void>> executeAsync() throws ConnectionException {
+                    public ListenableFuture<OperationResult<Void>> executeAsync() throws ConnectionException {
                         return executor.submit(new Callable<OperationResult<Void>>() {
                             @Override
                             public OperationResult<Void> call() throws Exception {
@@ -393,7 +395,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                     }
 
                     @Override
-                    public Future<OperationResult<Void>> executeAsync() throws ConnectionException {
+                    public ListenableFuture<OperationResult<Void>> executeAsync() throws ConnectionException {
                         return executor.submit(new Callable<OperationResult<Void>>() {
                             @Override
                             public OperationResult<Void> call() throws Exception {
@@ -489,23 +491,23 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                 if (schemas.size() > 1) {
                                     throw new SchemaDisagreementException("Can't create column family when there is a schema disagreement");
                                 }
-                                
+
                                 ThriftColumnFamilyDefinitionImpl def = new ThriftColumnFamilyDefinitionImpl();
-                                
+
                                 Map<String, Object> internalOptions = Maps.newHashMap();
                                 if (options != null)
                                     internalOptions.putAll(options);
-                                
+
                                 internalOptions.put("keyspace", getKeyspaceName());
-                                
+
                                 def.setFields(internalOptions);
-                                
+
                                 return new SchemaChangeResponseImpl()
                                     .setSchemaId(client.system_add_column_family(def.getThriftColumnFamilyDefinition()));
                             }
                         }, RunOnce.get());
     }
-    
+
     @Override
     public <K, C> OperationResult<SchemaChangeResult> createColumnFamily(final ColumnFamily<K, C> columnFamily, final Map<String, Object> options) throws ConnectionException {
         return connectionPool
@@ -518,13 +520,13 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                 if (schemas.size() > 1) {
                                     throw new SchemaDisagreementException("Can't create column family when there is a schema disagreement");
                                 }
-                                
+
                                 ThriftColumnFamilyDefinitionImpl def = new ThriftColumnFamilyDefinitionImpl();
-                                
+
                                 Map<String, Object> internalOptions = Maps.newHashMap();
                                 if (options != null)
                                     internalOptions.putAll(options);
-                                
+
                                 internalOptions.put("name", columnFamily.getName());
                                 internalOptions.put("keyspace", getKeyspaceName());
                                 if (!internalOptions.containsKey("comparator_type"))
@@ -533,15 +535,15 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                     internalOptions.put("key_validation_class", columnFamily.getKeySerializer().getComparatorType().getTypeName());
                                 if (columnFamily.getDefaultValueSerializer() != null && !internalOptions.containsKey("default_validation_class"))
                                     internalOptions.put("default_validation_class", columnFamily.getDefaultValueSerializer().getComparatorType().getTypeName());
-                                
+
                                 def.setFields(internalOptions);
-                                
+
                                 return new SchemaChangeResponseImpl()
                                     .setSchemaId(client.system_add_column_family(def.getThriftColumnFamilyDefinition()));
                             }
                         }, RunOnce.get());
     }
-    
+
     @Override
     public <K, C> OperationResult<SchemaChangeResult> updateColumnFamily(final ColumnFamily<K, C> columnFamily, final Map<String, Object> options) throws ConnectionException  {
         return connectionPool
@@ -554,9 +556,9 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                 if (schemas.size() > 1) {
                                     throw new SchemaDisagreementException("Can't update column family when there is a schema disagreement");
                                 }
-                                
+
                                 ThriftColumnFamilyDefinitionImpl def = new ThriftColumnFamilyDefinitionImpl();
-                                
+
                                 Map<String, Object> internalOptions = Maps.newHashMap();
                                 if (options != null)
                                     internalOptions.putAll(options);
@@ -564,9 +566,9 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                 internalOptions.put("keyspace",             getKeyspaceName());
                                 if (!internalOptions.containsKey("key_validation_class"))
                                     internalOptions.put("key_validation_class", columnFamily.getKeySerializer().getComparatorType().getTypeName());
-                                
+
                                 def.setFields(internalOptions);
-                                
+
                                 return new SchemaChangeResponseImpl()
                                     .setSchemaId(client.system_update_column_family(def.getThriftColumnFamilyDefinition()));
                             }
@@ -621,16 +623,16 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                 if (schemas.size() > 1) {
                                     throw new SchemaDisagreementException("Can't create keyspace when there is a schema disagreement");
                                 }
-                                
+
                                 ThriftKeyspaceDefinitionImpl def = new ThriftKeyspaceDefinitionImpl();
-                                
+
                                 Map<String, Object> internalOptions = Maps.newHashMap();
                                 if (options != null)
                                     internalOptions.putAll(options);
                                 internalOptions.put("name",                 getKeyspaceName());
-                                
+
                                 def.setFields(internalOptions);
-                                
+
                                 return new SchemaChangeResponseImpl()
                                     .setSchemaId(client.system_add_keyspace(def.getThriftKeyspaceDefinition()));
                             }
@@ -650,16 +652,16 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                 if (schemas.size() > 1) {
                                     throw new SchemaDisagreementException("Can't update keyspace when there is a schema disagreement");
                                 }
-                                
+
                                 ThriftKeyspaceDefinitionImpl def = new ThriftKeyspaceDefinitionImpl();
-                                
+
                                 Map<String, Object> internalOptions = Maps.newHashMap();
                                 if (options != null)
                                     internalOptions.putAll(options);
                                 internalOptions.put("name",                 getKeyspaceName());
-                                
+
                                 def.setFields(internalOptions);
-                                
+
                                 return new SchemaChangeResponseImpl()
                                     .setSchemaId(client.system_update_keyspace(def.getThriftKeyspaceDefinition()));
                             }
@@ -678,7 +680,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                 if (schemas.size() > 1) {
                                     throw new SchemaDisagreementException("Can't drop keyspace when there is a schema disagreement");
                                 }
-                                
+
                                 return new SchemaChangeResponseImpl()
                                     .setSchemaId(client.system_drop_keyspace(getKeyspaceName()));
                             }


### PR DESCRIPTION
This patch implements issue #11.

Being able to use astyanax in a non-blocking fashion, respectively registering callbacks on asynchronous Cassandra operations is an absolute necessity for some of our applications. Since using `ListenableFuture` is a compatible change, could you at least comment on the choice to use the plain Java `Future`?
