### PR TITLE
StackOverflow in ThriftColumnFamilyQueryImpl<K, C> 

### DIFF
--- a/src/main/java/com/netflix/astyanax/thrift/ThriftColumnFamilyQueryImpl.java
+++ b/src/main/java/com/netflix/astyanax/thrift/ThriftColumnFamilyQueryImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 Netflix
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -88,15 +88,15 @@ import com.netflix.astyanax.util.TokenGenerator;
 
 /**
  * Implementation of all column family queries using the thrift API.
- * 
+ *
  * @author elandau
- * 
+ *
  * @param <K>
  * @param <C>
  */
 public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C> {
     private final static Logger LOG = LoggerFactory.getLogger(ThriftColumnFamilyQueryImpl.class);
-    
+
     private final ConnectionPool<Cassandra.Client> connectionPool;
     private final ColumnFamily<K, C> columnFamily;
     private final KeyspaceTracerFactory tracerFactory;
@@ -300,7 +300,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
             public RowCopier<K, C> copyTo(final ColumnFamily<K, C> otherColumnFamily, final K otherRowKey) {
                 return new RowCopier<K, C>() {
                     private boolean useOriginalTimestamp = true;
-                    
+
                     @Override
                     public OperationResult<Void> execute() throws ConnectionException {
                         return connectionPool.executeWithFailover(
@@ -309,9 +309,9 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                         .getKeyspaceName()) {
                                     @Override
                                     public Void internalExecute(Client client, ConnectionContext context) throws Exception {
-                                        
+
                                         long currentTime = keyspace.getConfig().getClock().getCurrentTime();
-                                        
+
                                         List<ColumnOrSuperColumn> columnList = client.get_slice(columnFamily
                                                 .getKeySerializer().toByteBuffer(rowKey), new ColumnParent()
                                                 .setColumn_family(columnFamily.getName()), predicate, ThriftConverter
@@ -322,7 +322,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                         List<Mutation> mutationList = new ArrayList<Mutation>();
                                         for (ColumnOrSuperColumn sosc : columnList) {
                                             ColumnOrSuperColumn cosc;
-                                            
+
                                             if (sosc.isSetColumn()) {
                                                 cosc = new ColumnOrSuperColumn().setColumn(sosc.getColumn());
                                                 if (!useOriginalTimestamp)
@@ -346,7 +346,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                             else {
                                                 continue;
                                             }
-                                            
+
                                             mutationList.add(new Mutation().setColumn_or_supercolumn(cosc));
                                         }
 
@@ -445,7 +445,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
             }
         };
     }
-    
+
     @Override
     public RowSliceQuery<K, C> getKeySlice(final Iterable<K> keys) {
         return new AbstractRowSliceQueryImpl<K, C>(columnFamily.getColumnSerializer()) {
@@ -494,9 +494,9 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                     @Override
                                     public Map<K, Integer> internalExecute(Client client, ConnectionContext context) throws Exception {
                                         Map<ByteBuffer, Integer> cfmap = client.multiget_count(
-                                                columnFamily.getKeySerializer().toBytesList(keys), 
-                                                new ColumnParent().setColumn_family(columnFamily.getName()), 
-                                                predicate, 
+                                                columnFamily.getKeySerializer().toBytesList(keys),
+                                                new ColumnParent().setColumn_family(columnFamily.getName()),
+                                                predicate,
                                                 ThriftConverter.ToThriftConsistencyLevel(consistencyLevel));
                                         if (cfmap == null || cfmap.isEmpty()) {
                                             return Maps.newHashMap();
@@ -526,7 +526,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
     public RowSliceQuery<K, C> getKeySlice(final K keys[]) {
         return getKeySlice(Arrays.asList(keys));
     }
-    
+
     @Override
     public RowSliceQuery<K, C> getKeySlice(final Collection<K> keys) {
         return new AbstractRowSliceQueryImpl<K, C>(columnFamily.getColumnSerializer()) {
@@ -652,7 +652,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                 }
                                 else {
                                     if (isPaginating) {
-                                        if (!firstPage && !cfmap.isEmpty() && 
+                                        if (!firstPage && !cfmap.isEmpty() &&
                                               cfmap.get(0).bufferForKey().equals(indexClause.bufferForStart_key())) {
                                             cfmap.remove(0);
                                         }
@@ -701,7 +701,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                             @Override
                             public CqlResult<K, C> internalExecute(Client client, ConnectionContext context) throws Exception {
                                 org.apache.cassandra.thrift.CqlResult res = client.execute_cql_query(
-                                        StringSerializer.get().toByteBuffer(cql), 
+                                        StringSerializer.get().toByteBuffer(cql),
                                         useCompression ? Compression.GZIP : Compression.NONE);
                                 switch (res.getType()) {
                                 case ROWS:
@@ -778,7 +778,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
             }
         };
     }
-    
+
     @Override
     public AllRowsQuery<K, C> getAllRows() {
         return new AbstractThriftAllRowsQueryImpl<K, C>(columnFamily) {
@@ -849,10 +849,10 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                 else {
                     return !getIncludeEmptyRows();
                 }
-                
+
                 return true;
             }
-            
+
             @Override
             public void executeWithCallback(final RowCallback<K, C> callback) throws ConnectionException {
                 final RandomPartitioner partitioner = new RandomPartitioner();
@@ -866,7 +866,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                     for (int i = 0; i < nThreads; i++) {
                         BigIntegerToken start =  new BigIntegerToken(TokenGenerator.initialToken(nThreads, i,   getStartToken(), getEndToken()));
                         BigIntegerToken end   =  new BigIntegerToken(TokenGenerator.initialToken(nThreads, i+1, getStartToken(), getEndToken()));
-                        
+
                         try {
                             Pair<String, String> pair = Pair.create(checkpointManager.getCheckpoint(start.toString()), end.toString());
                             if (pair.left == null) {
@@ -890,7 +890,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                     });
                 }
                 final CountDownLatch doneSignal = new CountDownLatch(ranges.size());
-                
+
                 for (final Pair<String, String> tokenPair : ranges) {
                     // Prepare the range of tokens for this token range
                     final KeyRange range = new KeyRange()
@@ -909,7 +909,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                             }
                             return null;
                         }
-                        
+
                         private boolean internalRun() throws Exception {
                             try {
                                 // Get the next block
@@ -926,7 +926,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                                         predicate, range, ThriftConverter
                                                                 .ToThriftConsistencyLevel(consistencyLevel));
                                             }
-    
+
                                             @Override
                                             public ByteBuffer getRowKey() {
                                                 if (range.getStart_key() != null)
@@ -934,11 +934,11 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                                 return null;
                                             }
                                         }, retry.duplicate()).getResult();
-    
+
                                 // Notify the callback
                                 if (!ks.isEmpty()) {
                                     KeySlice lastRow = Iterables.getLast(ks);
-                                    
+
                                     boolean bContinue = ks.size() == getBlockSize();
                                     if (bIgnoreTombstones) {
                                         Iterator<KeySlice> iter = ks.iterator();
@@ -957,7 +957,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                         error.set(ce);
                                         return false;
                                     }
-                                    
+
                                     if (bContinue) {
                                         // Determine the start token
                                         // for the next page
@@ -990,7 +990,7 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                     return false;
                                 }
                             }
-                            
+
                             return true;
                         }
                     });
@@ -1044,6 +1044,6 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
 
     @Override
     public RowSliceQuery<K, C> getRowSlice(Iterable<K> keys) {
-        return getRowSlice(keys);
+        return getKeySlice(keys);
     }
 }


### PR DESCRIPTION
public RowSliceQuery<K, C> getRowSlice(Iterable<K> keys) {
called itself, leading to a StackOverflow. This fixes
the issue. However, it is unclear why both getRowSlice
and getKeySlice exist, as one seems to just be an alias
for the other
