### PR TITLE
Fix AnnotatedCompositeSerializer to allow generics.

### DIFF
--- a/src/main/java/com/netflix/astyanax/serializers/AnnotatedCompositeSerializer.java
+++ b/src/main/java/com/netflix/astyanax/serializers/AnnotatedCompositeSerializer.java
@@ -56,7 +56,7 @@ public class AnnotatedCompositeSerializer<T> extends AbstractSerializer<T> {
         }
 
         public void deserialize(Object obj, ByteBuffer value) throws IllegalArgumentException, IllegalAccessException {
-           	field.set(obj, getSerializer(field.get(obj)).fromByteBuffer(value));
+           	field.set(obj, getSerializer(obj).fromByteBuffer(value));
         }
 
         public ByteBuffer serializeValue(Object value) {

--- a/src/test/java/com/netflix/astyanax/serializers/SerializersTest.java
+++ b/src/test/java/com/netflix/astyanax/serializers/SerializersTest.java
@@ -420,6 +420,46 @@ public class SerializersTest {
 			Assert.fail();
 		}
 	}
+	
+	@Test
+	public void testAnnotatedCompositeSerializerWithGenerics(){
+	    try{
+	        AnnotatedCompositeSerializer<GenericComposite> ser = new AnnotatedCompositeSerializer<GenericComposite>(GenericComposite.class);
+	        GenericComposite<String, String> c1 = new GenericComposite<String, String>("foo","bar");
+	        
+	        ByteBuffer bytes = ser.toByteBuffer(c1);
+	        GenericComposite<String, String> c2 = ser.fromByteBuffer(bytes);
+	        Assert.assertEquals(c1, c2);
+	    } catch (Exception e){
+	        e.printStackTrace();
+	        LOG.error(e.getMessage());
+	        Assert.fail();
+	    }
+	}
+	
+	static class GenericComposite<A, B>{
+	    @Component(ordinal = 0)
+	    A a;
+	    
+	    @Component(ordinal = 1)
+	    B b;
+	    
+	    public GenericComposite(){}
+	    
+	    public GenericComposite(A a, B b){
+	        this.a = a;
+	        this.b = b;
+	    }
+	    
+	    @Override
+	    public boolean equals(Object arg0){
+	        if(!(arg0 instanceof GenericComposite)){
+	            return false;
+	        }
+	        GenericComposite other = (GenericComposite)arg0;
+	        return a.equals(other.a) && b.equals(other.b); 
+	    }
+	}
 
 	static class Composite2 {
 		@Component(ordinal = 0)


### PR DESCRIPTION
This is (somewhat of a hack) fix that allows AnnotatedCompositeSerializer to properly handle annotated generic classes, such as:

```
static class GenericComposite<A, B>{
    @Component(ordinal = 0)
    A a;

    @Component(ordinal = 1)
    B b;

    public GenericComposite(){}

    public GenericComposite(A a, B b){
        this.a = a;
        this.b = b;
    }
}
```

Without it, attempts to serialize and instance of the above class would be met with a cryptic error such as "X did not validate".

The solution was to modify AnnotatedCompositeSerializer so that it waits to infer the serializer until it is actually asked to (de)serialize an @Component object.

Dealing with `null` values was a bit hacky since we can't really infer the type of a null, so instead we delegate to the class definition.

My apologies if I violated formatting rules... I use spaces(no tabs), but it looks like Netflix uses a combination. Feel free to kick it back if that's an issue.
