### PR TITLE
Support pagination for counter columns

### DIFF
--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftColumnFamilyQueryImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftColumnFamilyQueryImpl.java
@@ -237,6 +237,8 @@ public class ThriftColumnFamilyQueryImpl<K, C> implements ColumnFamilyQuery<K, C
                                         ColumnOrSuperColumn last = Iterables.getLast(columnList);
                                         if (last.isSetColumn()) {
                                             predicate.getSlice_range().setStart(last.getColumn().getName());
+                                        } else if (last.isSetCounter_column()) {
+                                            predicate.getSlice_range().setStart(last.getCounter_column().getName());
                                         }
                                     }
                                 }


### PR DESCRIPTION
Code from Pagination part of Getting Started document:

``` java
RowQuery<String, String> query = keyspace
    .prepareQuery(CF_STANDARD1)
    .getKey("TheRowKey")
    .autoPaginate(true));

while (!(columns = query.execute().getResult()).isEmpty()) {
    for (Column<String> c : columns) {
        System.out.println.info(c.getName());
    }
}
```

will loop infinitely if run on a column family containing counter columns.
This patch checks if column is a counter and sets corresponding predicate for next page.
