### PR TITLE
Fix duplicate recurring events

### DIFF
--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/DuplicateMessageException.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/DuplicateMessageException.java
@@ -1,0 +1,17 @@
+package com.netflix.astyanax.recipes.queue;
+
+public class DuplicateMessageException extends Exception {
+    private static final long serialVersionUID = 3917437309288808628L;
+
+    public DuplicateMessageException(String message) {
+        super(message);
+    }
+
+    public DuplicateMessageException(Throwable t) {
+        super(t);
+    }
+
+    public DuplicateMessageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/Message.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/Message.java
@@ -12,7 +12,7 @@ import com.netflix.astyanax.util.TimeUUIDUtils;
 
 public class Message {
     
-    private static final int DEFAULT_TIMEOUT        = 5;
+    private static final int DEFAULT_TIMEOUT_SECONDS = 120;
     
     /**
      * Last execution time, this value changes as the task state is transitioned.  
@@ -44,7 +44,7 @@ public class Message {
     /**
      * Timeout value in seconds
      */
-    private int timeout = DEFAULT_TIMEOUT;
+    private int timeout = DEFAULT_TIMEOUT_SECONDS;
     
     /**
      * Unique key for this message.
@@ -238,9 +238,27 @@ public class Message {
 
     @Override
     public String toString() {
-        return "Message [token=" + token + ", random=" + random + ", trigger=" + trigger + ", parameters=" + parameters
-                + ", priority=" + priority + ", timeout=" + timeout + ", key=" + key + ", taskClass=" + taskClass
-                + ", isKeepHistory=" + isKeepHistory + ", hasUniqueKey=" + hasUniqueKey + "]";
+    	StringBuilder sb = new StringBuilder();
+    	sb.append("Message[token=" + token + " (" + TimeUUIDUtils.getMicrosTimeFromUUID(token) + ")");
+    	if (random != null)
+    		sb.append(", random=" + random);
+    	if (trigger != null)
+    		sb.append(", trigger=" + trigger);
+    	if (parameters != null)
+    		sb.append(", parameters=" + parameters);
+		sb.append(", priority=" + priority);
+		sb.append(", timeout=" + timeout);
+		if (key != null)
+			sb.append(", key=" + key);
+		if (hasUniqueKey)
+			sb.append(", hasUniqueKey=" + hasUniqueKey);
+		if (taskClass != null)
+			sb.append(", taskClass=" + taskClass);
+		if (isKeepHistory)
+			sb.append(", isKeepHistory=" + isKeepHistory);
+		
+		sb.append("]");
+		return sb.toString();
     }
 
 }

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageContext.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageContext.java
@@ -75,6 +75,13 @@ public class MessageContext {
     
     @Override
     public String toString() {
-        return "MessageContext [message=" + message + ", nextMessage=" + nextMessage + ", ackMessageId=" + ackMessageId + "]";
+    	StringBuilder sb = new StringBuilder();
+    	sb.append("MessageContext [")
+    	  .append("ackMessageId=" + ackMessageId)
+    	  .append(", message=" + message)
+    	  .append(", nextMessage=" + nextMessage)
+    	  .append("]");
+    	
+    	return sb.toString();
     }
 }

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageMetadataEntry.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageMetadataEntry.java
@@ -54,14 +54,9 @@ public class MessageMetadataEntry {
     }
 
     public static MessageMetadataEntry newLock() {
-        return new MessageMetadataEntry(MessageMetadataEntryType.Unique, TimeUUIDUtils.getUniqueTimeUUIDinMicros().toString());
+        return new MessageMetadataEntry(MessageMetadataEntryType.Lock,   TimeUUIDUtils.getUniqueTimeUUIDinMicros().toString());
     }
     
-    @Override
-    public String toString() {
-        return "MessageMetadata [type=" + type + ", name=" + name + "]";
-    }
-
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -91,5 +86,10 @@ public class MessageMetadataEntry {
         } else if (!type.equals(other.type))
             return false;
         return true;
+    }
+    
+    @Override
+    public String toString() {
+        return "MessageMetadata [type=" + MessageMetadataEntryType.values()[type] + ", name=" + name + "]";
     }
 }

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueDispatcher.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueDispatcher.java
@@ -28,7 +28,7 @@ public class MessageQueueDispatcher {
     private static final Logger LOG = LoggerFactory.getLogger(MessageQueueDispatcher.class);
     
     public final static int   DEFAULT_BATCH_SIZE            = 5;
-    public final static int   DEFAULT_THROTTLE_DURATION     = 1000;
+    public final static int   DEFAULT_POLLING_INTERVAL     = 1000;
     public final static int   DEFAULT_THREAD_COUNT          = 1;
     public final static int   DEFAULT_CONSUMER_COUNT        = 1;
     public final static int   DEFAULT_ACK_SIZE              = 100;
@@ -115,7 +115,7 @@ public class MessageQueueDispatcher {
          * @param units
          */
         public Builder withPollingInterval(long interval, TimeUnit units) {
-            dispatcher.pollingInterval = TimeUnit.SECONDS.convert(interval, units);
+            dispatcher.pollingInterval = TimeUnit.MILLISECONDS.convert(interval, units);
             return this;
         }
         
@@ -154,7 +154,7 @@ public class MessageQueueDispatcher {
     private int             ackSize       = DEFAULT_ACK_SIZE;
     private long            ackInterval   = DEFAULT_ACK_INTERVAL;
     private int             backlogSize   = DEFAULT_BACKLOG_SIZE;
-    private long            pollingInterval = DEFAULT_THROTTLE_DURATION;
+    private long            pollingInterval = DEFAULT_POLLING_INTERVAL;
     private boolean         terminate     = false;
     private MessageQueue    messageQueue;
     private ExecutorService executor;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntry.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntry.java
@@ -144,8 +144,15 @@ public class MessageQueueEntry {
 
     @Override
     public String toString() {
-        return "MessageQueueEntry [type=" + type + ", priority=" + priority + ", timestamp=" + timestamp + ", random=" + random
-                + ", state=" + state + "]";
+        StringBuilder sb = new StringBuilder();
+        sb.append("MessageQueueEntry [");
+        sb.append(  "type="      + MessageQueueEntryType.values()[type]);
+        sb.append(", priority="  + priority);
+        sb.append(", timestamp=" + timestamp + "(" + TimeUUIDUtils.getMicrosTimeFromUUID(timestamp) + ")");
+        sb.append(", random="    + random);
+        sb.append(", state="     + MessageQueueEntryState.values()[state]);
+        sb.append("]");
+        return sb.toString();
     }
     
     

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/RepeatingTrigger.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/RepeatingTrigger.java
@@ -98,6 +98,15 @@ public class RepeatingTrigger extends AbstractTrigger {
 
     @Override
     public String toString() {
-        return "RepeatingTrigger [delay=" + delay + ", interval=" + interval + ", repeatCount=" + repeatCount + ", endTime=" + endTime + "] " + super.toString();
+    	StringBuilder sb = new StringBuilder();
+    	sb.append("RepeatingTrigger[interval=" + interval);
+    	if (delay != null)
+    		sb.append(", delay=" + delay);
+    	if (repeatCount != null) 
+    		sb.append(", repeatCount=" + repeatCount);
+    	if (endTime > 0) 
+    		sb.append(", endTime=" + endTime);
+    	sb.append("]");
+    	return sb.toString();
     }
 }

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/reader/AllRowsReader.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/reader/AllRowsReader.java
@@ -44,9 +44,11 @@ import com.netflix.astyanax.model.Rows;
 import com.netflix.astyanax.partitioner.BigInteger127Partitioner;
 import com.netflix.astyanax.partitioner.Partitioner;
 import com.netflix.astyanax.query.CheckpointManager;
+import com.netflix.astyanax.query.ColumnFamilyQuery;
 import com.netflix.astyanax.query.RowSliceQuery;
 import com.netflix.astyanax.shallows.EmptyCheckpointManager;
 import com.netflix.astyanax.util.Callables;
+import com.netflix.astyanax.model.ConsistencyLevel;
 
 /**
  * Recipe that is used to read all rows from a column family.  
@@ -79,7 +81,12 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
     private final   List<Future<Boolean>> futures = Lists.newArrayList();
     private final   AtomicBoolean       cancelling = new AtomicBoolean(false);
     private final   Partitioner         partitioner;
+    private final   ConsistencyLevel	consistencyLevel;
     private AtomicReference<Exception>  error = new AtomicReference<Exception>();
+
+	private String dc;
+
+	private String rack;
     
     public static class Builder<K, C> {
         private final Keyspace      keyspace;
@@ -97,6 +104,9 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
         private String              startToken;
         private String              endToken;
         private Boolean             includeEmptyRows;  // Default to null will discard tombstones
+        private String				dc;
+        private String				rack;
+        private ConsistencyLevel	consistencyLevel = null;
         
         public Builder(Keyspace ks, ColumnFamily<K, C> columnFamily) {
             this.keyspace     = ks;
@@ -271,6 +281,32 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
             return this;
         }
         
+        public Builder<K, C> withConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        	this.consistencyLevel = consistencyLevel;
+        	return this;
+        }
+        /**
+         * Specify dc to use when auto determining the token ranges to ensure that only ranges
+         * in the current dc are used.
+         * @param rack
+         * @return
+         */
+        public Builder<K, C> withDc(String dc) {
+        	this.dc = dc;
+        	return this;
+        }
+        
+        /**
+         * Specify rack to use when auto determining the token ranges to ensure that only ranges
+         * in the current rack are used.
+         * @param rack
+         * @return
+         */
+        public Builder<K,C> withRack(String rack) {
+        	this.rack = rack;
+        	return this;
+        }
+        
         public AllRowsReader<K,C> build() {
             if (partitioner == null) {
                 try {
@@ -292,7 +328,10 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
                     includeEmptyRows, 
                     pageSize,
                     repeatLastToken,
-                    partitioner);
+                    partitioner,
+                    dc,
+                    rack,
+                    consistencyLevel);
         }
     }
     
@@ -308,7 +347,10 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
             Boolean includeEmptyRows,
             int pageSize,
             boolean repeatLastToken,
-            Partitioner partitioner) {
+            Partitioner partitioner,
+            String dc,
+            String rack,
+            ConsistencyLevel consistencyLevel) {
         super();
         this.keyspace           = keyspace;
         this.columnFamily       = columnFamily;
@@ -323,6 +365,9 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
         this.pageSize           = pageSize;
         this.repeatLastToken    = repeatLastToken;
         this.partitioner        = partitioner;
+        this.dc					= dc;
+        this.rack				= rack;
+        this.consistencyLevel   = consistencyLevel;
         
         // Flag explicitly set
         if (includeEmptyRows != null) 
@@ -333,6 +378,13 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
         // Default to false
         else 
             this.includeEmptyRows = false;
+    }
+    
+    private ColumnFamilyQuery<K, C> prepareQuery() {
+    	ColumnFamilyQuery<K, C> query = keyspace.prepareQuery(columnFamily);
+    	if (consistencyLevel != null)
+    		query.setConsistencyLevel(consistencyLevel);
+    	return query;
     }
 
     private Callable<Boolean> makeTokenRangeTask(final String startToken, final String endToken) {
@@ -359,8 +411,7 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
                     int localPageSize = pageSize;
                     int rowsToSkip = 0;
                     while (!cancelling.get()) {
-                        RowSliceQuery<K, C> query = keyspace
-                            .prepareQuery(columnFamily).getKeyRange(null, null, currentToken, endToken, localPageSize);
+                        RowSliceQuery<K, C> query = prepareQuery().getKeyRange(null, null, currentToken, endToken, localPageSize);
                         
                         if (columnSlice != null)
                             query.withColumnSlice(columnSlice);
@@ -472,7 +523,7 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
         }
         // We are iterating through each token range
         else {
-            List<TokenRange> ranges = keyspace.describeRing();
+            List<TokenRange> ranges = keyspace.describeRing(dc, rack);
             for (TokenRange range : ranges) {
                 if (range.getStartToken().equals(range.getEndToken())) 
                     subtasks.add(makeTokenRangeTask(range.getStartToken(), range.getEndToken()));


### PR DESCRIPTION
The queue recipe can, under certain timeout conditions, produce
duplicate events.  This fix discards one the duplicates.
Added method to override the consistency level in the AllRowsReader.
