### PR TITLE
Fix mutation timestamp override NPE.

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/MutationBatch.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/MutationBatch.java
@@ -98,7 +98,8 @@ public interface MutationBatch extends Execution<Void> {
 
     /**
      * Discard any pending mutations. All previous references returned by row
-     * are now invalid.
+     * are now invalid.  Note also that this will reset the mutation timestamp
+     * so that the next call to withRow will set the timestamp to the current time
      */
     void discardMutations();
 

--- a/astyanax-recipes/conf/log4j.xml
+++ b/astyanax-recipes/conf/log4j.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
+<log4j:configuration>
+  <appender name="stdout" class="org.apache.log4j.ConsoleAppender">
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ABSOLUTE} %5p %c{1}:%L - %m%n"/>
+    </layout>
+  </appender>
+  <root>
+    <priority value="info"></priority>
+    <appender-ref ref="stdout"/>
+  </root>
+</log4j:configuration>

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/ColumnCounterFunction.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/ColumnCounterFunction.java
@@ -1,0 +1,34 @@
+package com.netflix.astyanax.recipes.functions;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.base.Function;
+import com.netflix.astyanax.model.Row;
+
+/**
+ * Very basic function to count the total number of columns
+ * 
+ * @author elandau
+ *
+ * @param <K>
+ * @param <C>
+ */
+public class ColumnCounterFunction<K,C> implements Function<Row<K,C>, Boolean> {
+
+    private final AtomicLong counter = new AtomicLong(0);
+    
+    @Override
+    public Boolean apply(Row<K,C> input) {
+        counter.addAndGet(input.getColumns().size());
+        return true;
+    }
+    
+    public long getCount() {
+        return counter.get();
+    }
+
+    public void reset() {
+        counter.set(0);
+    }
+
+}

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/RowCopierFunction.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/RowCopierFunction.java
@@ -1,0 +1,124 @@
+package com.netflix.astyanax.recipes.functions;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Sets;
+import com.netflix.astyanax.ColumnListMutation;
+import com.netflix.astyanax.Keyspace;
+import com.netflix.astyanax.MutationBatch;
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.netflix.astyanax.model.Column;
+import com.netflix.astyanax.model.ColumnFamily;
+import com.netflix.astyanax.model.Row;
+
+/**
+ * Function to copy rows into a target column family
+ * 
+ * TODO:  Failover, retry
+ *  
+ * @author elandau
+ *
+ * @param <K>
+ * @param <C>
+ */
+public class RowCopierFunction<K,C> implements Function<Row<K,C>, Boolean>, Flushable {
+    private static final Logger LOG = LoggerFactory.getLogger(RowCopierFunction.class);
+    
+    private static final int DEFAULT_BATCH_SIZE = 100;
+    
+    public static class Builder<K,C> {
+        private final ColumnFamily<K,C> columnFamily;
+        private final Keyspace          keyspace;
+        private       int               batchSize           = DEFAULT_BATCH_SIZE;
+        
+        public Builder(Keyspace keyspace, ColumnFamily<K,C> columnFamily) {
+            this.columnFamily = columnFamily;
+            this.keyspace     = keyspace;
+        }
+        
+        public Builder<K,C> withBatchSize(int batchSize) {
+            this.batchSize = batchSize;
+            return this;
+        }
+        
+        public RowCopierFunction<K,C> build() {
+            return new RowCopierFunction<K,C>(this);
+        }
+    }
+
+    public static <K, C> Builder<K,C> builder(Keyspace keyspace, ColumnFamily<K,C> columnFamily) {
+        return new Builder<K,C>(keyspace, columnFamily);
+    }
+    
+    private final ColumnFamily<K,C> columnFamily;
+    private final Keyspace          keyspace;
+    private final int               batchSize;
+    private final ThreadLocal<ThreadContext> context = new ThreadLocal<ThreadContext>();
+    private final Set<ThreadContext> contexts = Sets.newIdentityHashSet();
+    
+    private static class ThreadContext {
+        MutationBatch mb;
+        int counter = 0;
+    }
+    
+    private RowCopierFunction(Builder<K,C> builder) {
+        this.columnFamily = builder.columnFamily;
+        this.batchSize    = builder.batchSize;
+        this.keyspace     = builder.keyspace;
+    }
+    
+    @Override
+    public Boolean apply(@Nullable Row<K, C> row) {
+        ThreadContext context = this.context.get();
+        if (context == null) {
+            context = new ThreadContext();
+            context.mb = keyspace.prepareMutationBatch();
+            this.context.set(context);
+            
+            synchronized (this) {
+                contexts.add(context);
+            }
+        }
+        
+        ColumnListMutation<C> mbRow = context.mb.withRow(columnFamily, row.getKey());
+        context.mb.lockCurrentTimestamp();
+        for (Column<C> column : row.getColumns()) {
+            mbRow.setTimestamp(column.getTimestamp());
+            mbRow.putColumn(column.getName(), column.getByteBufferValue(), column.getTtl());
+        }
+        
+        context.counter++;
+        if (context.counter == batchSize) {
+            try {
+                context.mb.execute();
+                context.counter = 0;
+            }
+            catch (Exception e) {
+                LOG.error("Failed to write mutation", e);
+                return false;
+            }
+            
+        }
+        return true;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        for (ThreadContext context : contexts) {
+            try {
+                context.mb.execute();
+            } catch (ConnectionException e) {
+                LOG.error("Failed to write mutation", e);
+            }
+        }
+    }
+
+}

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/RowCounterFunction.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/RowCounterFunction.java
@@ -1,0 +1,33 @@
+package com.netflix.astyanax.recipes.functions;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.base.Function;
+import com.netflix.astyanax.model.Row;
+
+/**
+ * Simple function to counter the number of rows
+ * 
+ * @author elandau
+ *
+ * @param <K>
+ * @param <C>
+ */
+public class RowCounterFunction<K,C> implements Function<Row<K,C>, Boolean> {
+
+    private final AtomicLong counter = new AtomicLong(0);
+    
+    @Override
+    public Boolean apply(Row<K,C> input) {
+        counter.incrementAndGet();
+        return true;
+    }
+    
+    public long getCount() {
+        return counter.get();
+    }
+
+    public void reset() {
+        counter.set(0);
+    }
+}

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/TraceFunction.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/TraceFunction.java
@@ -1,0 +1,77 @@
+package com.netflix.astyanax.recipes.functions;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import com.google.common.base.Function;
+import com.netflix.astyanax.model.Column;
+import com.netflix.astyanax.model.ColumnFamily;
+import com.netflix.astyanax.model.Row;
+
+/**
+ * Simple function to trace the contents
+ * @author elandau
+ *
+ * @param <K>
+ * @param <C>
+ */
+public class TraceFunction<K,C> implements Function<Row<K,C>, Boolean> {
+
+    public static class Builder<K,C> {
+        private OutputStream out = System.out;
+        private boolean showColumns = false;
+        
+        public Builder(ColumnFamily<K,C> columnFamily) {
+        }
+        
+        public Builder<K,C> withOutputStream(OutputStream out) {
+            this.out = out;
+            return this;
+        }
+        
+        public Builder<K,C> withShowColumns(boolean showColumns) {
+            this.showColumns = showColumns;
+            return this;
+        }
+        
+        public TraceFunction<K,C> build() {
+            return new TraceFunction<K,C>(this);
+        }
+    }
+
+    public static <K, C> Builder<K,C> builder(ColumnFamily<K,C> columnFamily) {
+        return new Builder<K,C>(columnFamily);
+    }
+    
+    private final OutputStream out;
+    private final boolean showColumns;
+    
+    private TraceFunction(Builder<K,C> builder) {
+        this.out                    = builder.out;
+        this.showColumns            = builder.showColumns;
+    }
+    
+    @Override
+    public synchronized Boolean apply(Row<K, C> row) {
+        long size = 0;
+        for (Column<C> column : row.getColumns()) {
+            size += column.getRawName().limit() + column.getByteBufferValue().limit();
+        }
+        
+        StringBuilder sb = new StringBuilder();
+        
+        sb.append(String.format("- row: '%s' size: '%dl' count: '%dl' \n", row.getKey(), size, row.getColumns().size()));
+        if (showColumns) {
+            for (Column<C> column : row.getColumns()) {
+                sb.append(String.format("  '%s' (ts='%dl', ttl='%d')\n", column.getName(), column.getTimestamp(), column.getTtl()));
+            }
+        }
+        try {
+            out.write(sb.toString().getBytes());
+        } catch (IOException e) {
+        }
+        return true;
+    }
+    
+
+}

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/reader/AllRowsReader.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/reader/AllRowsReader.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.netflix.astyanax.recipes.reader;
 
+import java.io.Flushable;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
@@ -583,6 +584,10 @@ public class AllRowsReader<K, C> implements Callable<Boolean> {
                 cancel();
                 throw e;
             }
+        }
+        
+        if (this.rowFunction instanceof Flushable) {
+            ((Flushable)rowFunction).flush();
         }
         return true;
     }


### PR DESCRIPTION
Fix for https://github.com/Netflix/astyanax/issues/236.
Added a bunch of 'sample' functions to be used with the all rows
reader: row copier, column counter, row counter, row trace.
