### PR TITLE
respect defined token ranges in iterator

### DIFF
--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftAllRowsImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftAllRowsImpl.java
@@ -56,10 +56,13 @@ public class ThriftAllRowsImpl<K, C> implements Rows<K, C> {
             private boolean bIgnoreTombstones = true;
 
             {
+	            String startToken = query.getStartToken() == null ? partitioner.getMinToken() : query.getStartToken();
+	            String endToken = query.getEndToken() == null ? partitioner.getMaxToken() : query.getEndToken();
+
                 range = new KeyRange()
                         .setCount(query.getBlockSize())
-                        .setStart_token(partitioner.getMinToken())
-                        .setEnd_token(partitioner.getMaxToken());
+                        .setStart_token(startToken)
+                        .setEnd_token(endToken);
                 
                 if (query.getIncludeEmptyRows() == null) {
                     if (query.getPredicate().isSetSlice_range() && query.getPredicate().getSlice_range().getCount() == 0) {


### PR DESCRIPTION
-if the user has specified a token range to be used in the AllRowsQuery and then requests an iterator, respect the token range requested instead of always iterating over all possible rows
