### PR TITLE
added missing getTransportErrorCount and created getHostActiveCount

### DIFF
--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolMonitor.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolMonitor.java
@@ -141,7 +141,12 @@ public interface ConnectionPoolMonitor {
      * @return Number of times operations were cancelled 
      */
     long getInterruptedCount();
-    
+
+    /**
+     * @return Number of times transport errors occurred
+     */
+    long getTransportErrorCount();
+
     /**
      * @return Return the number of hosts in the pool
      */
@@ -169,7 +174,12 @@ public interface ConnectionPoolMonitor {
      * @return Return the number of times any host was marked as down.
      */
     long getHostDownCount();
-    
+
+    /**
+     * @return Return the number of active hosts
+     */
+    long getHostActiveCount();
+
     /**
      * A host was added and given the associated pool. The pool is immutable and
      * can be used to get info about the number of open connections

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/CountingConnectionPoolMonitor.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/CountingConnectionPoolMonitor.java
@@ -234,6 +234,11 @@ public class CountingConnectionPoolMonitor implements ConnectionPoolMonitor {
     }
 
     @Override
+    public long getTransportErrorCount() {
+        return this.transportErrorCount.get();
+    }
+
+    @Override
     public long getBadRequestCount() {
         return this.badRequestCount.get();
     }
@@ -254,6 +259,11 @@ public class CountingConnectionPoolMonitor implements ConnectionPoolMonitor {
     @Override
     public long getHostCount() {
         return getHostAddedCount() - getHostRemovedCount();
+    }
+
+    @Override
+    public long getHostActiveCount() {
+        return hostAddedCount.get() - hostRemovedCount.get() + hostReactivatedCount.get() - hostDownCount.get();
     }
 
     public String toString() {
@@ -284,7 +294,7 @@ public class CountingConnectionPoolMonitor implements ConnectionPoolMonitor {
                     .append(",remove="     ).append(hostRemovedCount.get())
                     .append(",down="       ).append(hostDownCount.get())
                     .append(",reactivate=" ).append(hostReactivatedCount.get())
-                    .append(",active="     ).append(hostAddedCount.get() - hostRemovedCount.get() + hostReactivatedCount.get() - hostDownCount.get())
+                    .append(",active="     ).append(getHostActiveCount())
                 .append("])").toString();
     }
 

--- a/astyanax-core/src/main/java/com/netflix/astyanax/shallows/EmptyConnectionPoolMonitor.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/shallows/EmptyConnectionPoolMonitor.java
@@ -198,4 +198,14 @@ public class EmptyConnectionPoolMonitor implements ConnectionPoolMonitor {
     public long getHostDownCount() {
         return 0;
     }
+
+    @Override
+    public long getTransportErrorCount() {
+        return 0;
+    }
+
+    @Override
+    public long getHostActiveCount() {
+        return 0;
+    }
 }


### PR DESCRIPTION
added missing getTransportErrorCount and created getHostActiveCount in ConnectionPoolMonitor

I noticed there was no access to transportErrorCount when wanting to export the metrics from CountingConnectionPoolMonitorImpl.  I also added getHostActiveCount to capture the formula that was only in the toString method
