### PR TITLE
notFoundCounter() is not correct when using  Slf4jConnectionPoolMonitorImpl 

### DIFF
--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/Slf4jConnectionPoolMonitorImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/Slf4jConnectionPoolMonitorImpl.java
@@ -16,11 +16,11 @@ public class Slf4jConnectionPoolMonitorImpl extends CountingConnectionPoolMonito
     public void incOperationFailure(Host host, Exception reason) {
         if (reason instanceof NotFoundException) {
             // Ignore this
-            return;
         }
-
+        else {
+            LOG.warn(reason.getMessage());
+        }
         super.incOperationFailure(host, reason);
-        LOG.warn(reason.getMessage());
     }
 
     @Override

--- a/astyanax-core/src/test/java/com/netflix/astyanax/connectionpool/impl/Slf4jConnectionPoolMonitorImplTest.java
+++ b/astyanax-core/src/test/java/com/netflix/astyanax/connectionpool/impl/Slf4jConnectionPoolMonitorImplTest.java
@@ -1,0 +1,22 @@
+package com.netflix.astyanax.connectionpool.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.astyanax.connectionpool.exceptions.NoAvailableHostsException;
+import com.netflix.astyanax.connectionpool.exceptions.NotFoundException;
+
+public class Slf4jConnectionPoolMonitorImplTest {
+
+    @Test
+    public void testNotFoundCounter() {
+        Slf4jConnectionPoolMonitorImpl monitor = new Slf4jConnectionPoolMonitorImpl();
+        monitor.incOperationFailure(Host.NO_HOST, new NoAvailableHostsException("regular exception"));
+        Assert.assertEquals(0, monitor.notFoundCount());
+        Assert.assertEquals(1, monitor.getOperationFailureCount());
+        monitor.incOperationFailure(Host.NO_HOST, new NotFoundException("not found exception"));
+        Assert.assertEquals(1, monitor.notFoundCount());
+        Assert.assertEquals(1, monitor.getOperationFailureCount());
+    }
+}


### PR DESCRIPTION
If Slf4jConnectionPoolMonitorImpl is used the value of notFoundCounter will not be correct.
The problem is that incOperationFailure does not call super implementation in case of NotFoundException. 
It should not log it - at least it is not a warning but the super implementation should be called to update the counter returned by notFoundCounter() method.
