### PR TITLE
Fix NPE with EntityManager.find() and optional fields

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AbstractSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AbstractSerializer.java
@@ -39,6 +39,9 @@ public abstract class AbstractSerializer<T> implements Serializer<T> {
 
     @Override
     public T fromBytes(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
         return fromByteBuffer(ByteBuffer.wrap(bytes));
     }
 


### PR DESCRIPTION
When using the EntityManager, CQL3 and Cassandra 1.2.  It appears that it now requires that you properly define column mappings prior to being able to use the find method i.e: 

manager.find(SELECT \* FROM keyspace.\"columFamily\").  

However once define the mappings cassandra will return nulls for unpopulated optional fields.  This causes a NullPointerException in the AbstractSerializer when it attempts to wrap null in a ByteBuffer.

This fix corrects the NPE and allows you to once again have optional fields in the EntityManager.  
