### PR TITLE
EntityMapper for composite columns using OneToMany

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/ColumnPredicate.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/ColumnPredicate.java
@@ -1,0 +1,44 @@
+package com.netflix.astyanax.query;
+
+import com.netflix.astyanax.model.Equality;
+
+public class ColumnPredicate {
+    private String   name;
+    private Equality op;
+    private Object   value;
+    
+    public String getName() {
+        return name;
+    }
+
+    public Equality getOp() {
+        return op;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public ColumnPredicate setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ColumnPredicate setOp(Equality op) {
+        this.op = op;
+        return this;
+    }
+
+    public ColumnPredicate setValue(Object value) {
+        this.value = value;
+        return this;
+    }
+    
+    @Override
+    public String toString() {
+        return "ColumnPredicate [name=" + name + ", op=" + op + ", value="
+                + value + "]";
+    }
+
+    
+}

--- a/astyanax-entity-mapper/conf/log4j.xml
+++ b/astyanax-entity-mapper/conf/log4j.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
+<log4j:configuration>
+  <appender name="stdout" class="org.apache.log4j.ConsoleAppender">
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ABSOLUTE} %5p %c{1}:%L - %m%n"/>
+    </layout>
+  </appender>
+  <root>
+    <priority value="info"></priority>
+    <appender-ref ref="stdout"/>
+  </root>
+</log4j:configuration>

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeColumnEntityMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeColumnEntityMapper.java
@@ -3,8 +3,10 @@ package com.netflix.astyanax.entitystore;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Id;
@@ -14,10 +16,14 @@ import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.netflix.astyanax.ColumnListMutation;
 import com.netflix.astyanax.model.ColumnList;
+import com.netflix.astyanax.model.Equality;
+import com.netflix.astyanax.query.ColumnPredicate;
 
 /**
  * Mapper from a CompositeType to an embedded entity.  The composite entity is expected
@@ -28,9 +34,6 @@ import com.netflix.astyanax.model.ColumnList;
  *
  */
 public class CompositeColumnEntityMapper {
-    private final static int  COMPONENT_OVERHEAD = 3;
-    private final static byte END_OF_COMPONENT   = 0;
-    
     /**
      * Class of embedded entity
      */
@@ -40,6 +43,11 @@ public class CompositeColumnEntityMapper {
      * List of serializers for the composite parts
      */
     private List<FieldMapper<?>>    components = Lists.newArrayList();
+    
+    /**
+     * List of valid (i.e. existing) column names
+     */
+    private Set<String>             validNames = Sets.newHashSet();
     
     /**
      * Mapper for the value part of the entity
@@ -65,21 +73,18 @@ public class CompositeColumnEntityMapper {
         this.containerField.setAccessible(true);
         Field[] declaredFields = clazz.getDeclaredFields();
         for (Field f : declaredFields) {
-            // One of these for each component of the composite
-            Id idAnnotation = f.getAnnotation(Id.class);
-            if (idAnnotation != null) {
-                f.setAccessible(true);
-                components.add(new FieldMapper(f));
-            }
-            
             // The value
             Column columnAnnotation = f.getAnnotation(Column.class);
             if ((columnAnnotation != null)) {
-                Preconditions.checkArgument(valueMapper == null, "there should only be one value field");
                 f.setAccessible(true);
-                valueMapper = new FieldMapper(f);
+                FieldMapper fieldMapper = new FieldMapper(f);
+                components.add(fieldMapper);
+                validNames.add(fieldMapper.getName());
             }
-        }        
+        }
+        
+        // Last one is always treated as the 'value'
+        valueMapper = components.remove(components.size() - 1);
     }
     
     /**
@@ -134,37 +139,18 @@ public class CompositeColumnEntityMapper {
      * @return
      */
     public ByteBuffer toColumnName(Object obj) {
-        ByteBuffer bb = ByteBuffer.allocate(bufferSize);
+        SimpleCompositeBuilder composite = new SimpleCompositeBuilder(bufferSize, Equality.EQUAL);
 
         // Iterate through each component and add to a CompositeType structure
-        for (FieldMapper mapper : components) {
+        for (FieldMapper<?> mapper : components) {
             try {
-                // First, serialize the ByteBuffer for this component
-                ByteBuffer cb = mapper.toByteBuffer(obj);
-                if (cb == null) {
-                    cb = ByteBuffer.allocate(0);
-                }
-
-                if (cb.limit() + COMPONENT_OVERHEAD > bb.remaining()) {
-                    int exponent = (int) Math.ceil(Math.log((double) (cb.limit() + COMPONENT_OVERHEAD + bb.limit())) / Math.log(2));
-                    int newBufferSize = (int) Math.pow(2, exponent);
-                    ByteBuffer temp = ByteBuffer.allocate(newBufferSize);
-                    bb.flip();
-                    temp.put(bb);
-                    bb = temp;
-                }
-                // Write the data: <length><data><0>
-                bb.putShort((short) cb.remaining());
-                bb.put(cb.slice());
-                bb.put(END_OF_COMPONENT);
+                composite.addWithoutControl(mapper.toByteBuffer(obj));
             }
             catch (Exception e) {
-                e.printStackTrace();
                 throw new RuntimeException(e);
             }
         }
-        bb.flip();
-        return bb;
+        return composite.get();
     }
     
     /**
@@ -255,14 +241,14 @@ public class CompositeColumnEntityMapper {
      */
     public void setEntityFieldsFromColumnName(Object entity, ByteBuffer columnName) throws IllegalArgumentException, IllegalAccessException {
         // Iterate through components in order and set fields
-        for (FieldMapper component : components) {
+        for (FieldMapper<?> component : components) {
             ByteBuffer data = getWithShortLength(columnName);
             if (data != null) {
                 if (data.remaining() > 0) {
                     component.setField(entity, data);
                 }
                 byte end_of_component = columnName.get();
-                if (end_of_component != END_OF_COMPONENT) {
+                if (end_of_component != Equality.EQUAL.toByte()) {
                     throw new RuntimeException("Invalid composite column.  Expected END_OF_COMPONENT.");
                 }
             }
@@ -310,5 +296,45 @@ public class CompositeColumnEntityMapper {
 
     public String getValueType() {
         return valueMapper.getSerializer().getComparatorType().getClassName();
+    }
+
+    public ByteBuffer[] getQueryEndpoints(Collection<ColumnPredicate> predicates) {
+        // Convert to multimap for easy lookup
+        ArrayListMultimap<Object, ColumnPredicate> lookup = ArrayListMultimap.create();
+        for (ColumnPredicate predicate : predicates) {
+            Preconditions.checkArgument(validNames.contains(predicate.getName()), "Field '" + predicate.getName() + "' does not exist in the entity " + clazz.getCanonicalName());
+            lookup.put(predicate.getName(), predicate);
+        }
+        
+        SimpleCompositeBuilder start = new SimpleCompositeBuilder(bufferSize, Equality.GREATER_THAN_EQUALS);
+        SimpleCompositeBuilder end   = new SimpleCompositeBuilder(bufferSize, Equality.LESS_THAN_EQUALS);
+
+        // Iterate through components in order while applying predicate to 'start' and 'end'
+        for (FieldMapper<?> mapper : components) {
+            for (ColumnPredicate p : lookup.get(mapper.getName())) {
+                applyPredicate(mapper, start, end, p);
+            }
+        }
+        
+        return new ByteBuffer[]{start.get(), end.get()};
+    }
+    
+    private void applyPredicate(FieldMapper<?> mapper, SimpleCompositeBuilder start, SimpleCompositeBuilder end, ColumnPredicate predicate) {
+        ByteBuffer bb = mapper.valueToByteBuffer(predicate.getValue());
+        
+        switch (predicate.getOp()) {
+        case EQUAL:
+            start.addWithoutControl(bb);
+            end.addWithoutControl(bb);
+            break;
+        case GREATER_THAN:
+        case GREATER_THAN_EQUALS:
+            start.add(bb, predicate.getOp());
+            break;
+        case LESS_THAN:
+        case LESS_THAN_EQUALS:
+            end.add(bb, predicate.getOp());
+            break;
+        }
     }
 }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityMapper.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -15,10 +16,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.netflix.astyanax.ColumnListMutation;
 import com.netflix.astyanax.MutationBatch;
-import com.netflix.astyanax.model.Column;
 import com.netflix.astyanax.model.ColumnFamily;
 import com.netflix.astyanax.model.ColumnList;
-import com.netflix.astyanax.serializers.StringSerializer;
+import com.netflix.astyanax.query.ColumnPredicate;
 
 /**
  * The composite entity mapper expects an entity which has a single one to many
@@ -219,4 +219,7 @@ public class CompositeEntityMapper<T, K> {
         return embeddedEntityMapper.getValueType();
     }
 
+    public ByteBuffer[] getQueryEndpoints(Collection<ColumnPredicate> predicates) {
+        return this.embeddedEntityMapper.getQueryEndpoints(predicates);
+    }
 }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/DefaultEntityManager.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/DefaultEntityManager.java
@@ -491,4 +491,9 @@ public class DefaultEntityManager<T, K> implements EntityManager<T, K> {
         }
     }
 
+    @Override
+    public NativeQuery<T, K> createNativeQuery() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
 }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/EntityManager.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/EntityManager.java
@@ -91,6 +91,13 @@ public interface EntityManager<T, K> {
 	public List<T> find(String cql) throws PersistenceException;
 	
 	/**
+	 * Execute a 'native' query using a simple API that adheres to cassandra's native
+	 * model of rows and columns. 
+	 * @return
+	 */
+	public NativeQuery<T, K> createNativeQuery();
+	
+	/**
 	 * Create the underlying storage for this entity.  This should only be called
 	 * once when first creating store and not part of the normal startup sequence.
 	 * @throws PersistenceException

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/FieldMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/FieldMapper.java
@@ -3,6 +3,8 @@ package com.netflix.astyanax.entitystore;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 
+import javax.persistence.Column;
+
 import com.netflix.astyanax.Serializer;
 
 /**
@@ -14,10 +16,19 @@ import com.netflix.astyanax.Serializer;
 public class FieldMapper<T> {
     final Serializer<T>     serializer;
     final Field             field;
+    final String            name;
 
     public FieldMapper(final Field field) {
         this.serializer       = (Serializer<T>) MappingUtils.getSerializerForField(field);
         this.field            = field;
+        
+        Column columnAnnotation = field.getAnnotation(Column.class);
+        if (columnAnnotation == null || columnAnnotation.name().isEmpty()) {
+            name = field.getName();
+        }
+        else {
+            name = columnAnnotation.name();
+        }
     }
 
     public Serializer<?> getSerializer() {
@@ -36,11 +47,19 @@ public class FieldMapper<T> {
         return (T)field.get(entity);
     }
     
+    public ByteBuffer valueToByteBuffer(Object value) {
+        return serializer.toByteBuffer((T)value);
+    }
+    
     public void setValue(Object entity, Object value) throws IllegalArgumentException, IllegalAccessException {
         field.set(entity, value);
     }
     
     public void setField(Object entity, ByteBuffer buffer) throws IllegalArgumentException, IllegalAccessException {
         field.set(entity, fromByteBuffer(buffer));
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/NativeQuery.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/NativeQuery.java
@@ -1,0 +1,122 @@
+package com.netflix.astyanax.entitystore;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.netflix.astyanax.model.Equality;
+import com.netflix.astyanax.query.ColumnPredicate;
+
+/**
+ * SQL'ish like fluent API for defining a query.  This is mainly used by the various entity mappers
+ * to query for a subset of columns.  Each entity mapper stores data differently and will use the
+ * predicates here to make the correct lower level query.
+ * 
+ * @author elandau
+ *
+ * @param <T>
+ * @param <K>
+ */
+public abstract class NativeQuery<T, K> {
+    protected List<K>                 ids = Lists.newArrayList();
+    protected Collection<Object>      columnNames;
+    protected List<ColumnPredicate>   predicates;
+    protected Integer                 columnLimit = null;
+    
+    /**
+     * Refine query for row key
+     * @author elandau
+     *
+     */
+    public class NativeIdQuery {
+        public NativeQuery<T, K> in(Collection<K> keys) {
+            ids.addAll(keys);
+            return NativeQuery.this;
+        }
+        
+        public NativeQuery<T, K> in(K... keys) {
+            ids.addAll(Lists.newArrayList(keys));
+            return NativeQuery.this;
+        }
+        
+        public NativeQuery<T, K> equal(K key) {
+            ids.add(key);
+            return NativeQuery.this;
+        }
+    }
+    
+    /**
+     * Refine query for column range or slice
+     * @author elandau
+     *
+     */
+    public class NativeColumnQuery {
+        private ColumnPredicate predicate = new ColumnPredicate();
+        
+        public NativeColumnQuery(String name) {
+            predicate.setName(name);
+        }
+        
+        public NativeQuery<T, K> in(Collection<Object> names) {
+            columnNames = names;
+            return NativeQuery.this;
+        }
+
+        public NativeQuery<T, K> equal(Object value) {
+            return addPredicate(predicate.setOp(Equality.EQUAL).setValue(value));
+        }
+        
+        public NativeQuery<T, K> greaterThan(Object value) {
+            return addPredicate(predicate.setOp(Equality.GREATER_THAN).setValue(value));
+        }
+        
+        public NativeQuery<T, K> lessThan(Object value) {
+            return addPredicate(predicate.setOp(Equality.LESS_THAN).setValue(value));
+        }
+        
+        public NativeQuery<T, K> greaterThanEqual(Object value) {
+            return addPredicate(predicate.setOp(Equality.GREATER_THAN_EQUALS).setValue(value));
+        }
+        
+        public NativeQuery<T, K> lessThanEqual(Object value) {
+            return addPredicate(predicate.setOp(Equality.LESS_THAN_EQUALS).setValue(value));
+        }
+        
+    }
+    
+    public NativeIdQuery whereId() {
+        return new NativeIdQuery();
+    }
+    
+    public NativeColumnQuery whereColumn(String name) {
+        return new NativeColumnQuery(name);
+    }
+
+    public NativeQuery<T,K> limit(int columnLimit) {
+        this.columnLimit = columnLimit;
+        return this;
+    }
+    
+    private NativeQuery<T, K> addPredicate(ColumnPredicate predicate) {
+        if (predicates == null) {
+            predicates = Lists.newArrayList();
+        }
+        
+        predicates.add(predicate);
+        return this;
+    }
+
+    /**
+     * Return a single entity (or first) response
+     * @return
+     * @throws Exception
+     */
+    public abstract T getSingleResult() throws Exception;
+    
+    /**
+     * Return a result set of entities
+     * @return
+     * @throws Exception
+     */
+    public abstract Collection<T> getResultSet() throws Exception;
+}

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SimpleCompositeBuilder.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SimpleCompositeBuilder.java
@@ -1,0 +1,76 @@
+package com.netflix.astyanax.entitystore;
+
+import java.nio.ByteBuffer;
+
+import com.google.common.base.Preconditions;
+import com.netflix.astyanax.model.Equality;
+
+/**
+ * Yet another attempt at simplifying how composite columns are built
+ * 
+ * @author elandau
+ *
+ */
+public class SimpleCompositeBuilder {
+    private final static int  COMPONENT_OVERHEAD = 3;
+    
+    private int bufferSize;
+    private ByteBuffer bb;
+    private boolean hasControl = true;
+    private Equality lastEquality = Equality.EQUAL;
+    private final Equality finalEquality;
+    
+    public SimpleCompositeBuilder(int bufferSize, Equality finalEquality) {
+        bb = ByteBuffer.allocate(bufferSize);
+        this.finalEquality = finalEquality;
+    }
+    
+    public void add(ByteBuffer cb, Equality control) {
+        addWithoutControl(cb);
+        addControl(control);
+    }
+    
+    public void addWithoutControl(ByteBuffer cb) {
+        Preconditions.checkState(lastEquality == Equality.EQUAL, "Cannot extend composite since non equality control already set");
+        
+        if (!hasControl)
+            addControl(Equality.EQUAL);
+        
+        if (cb == null) {
+            cb = ByteBuffer.allocate(0);
+        }
+
+        if (cb.limit() + COMPONENT_OVERHEAD > bb.remaining()) {
+            int exponent = (int) Math.ceil(Math.log((double) (cb.limit() + COMPONENT_OVERHEAD + bb.limit())) / Math.log(2));
+            bufferSize = (int) Math.pow(2, exponent);
+            ByteBuffer temp = ByteBuffer.allocate(bufferSize);
+            bb.flip();
+            temp.put(bb);
+            bb = temp;
+        }
+        // Write the data: <length><data>
+        bb.putShort((short) cb.remaining());
+        bb.put(cb.slice());
+        hasControl = false;
+    }
+    
+    public void addControl(Equality control) {
+        Preconditions.checkState(!hasControl, "Control byte already set");
+        Preconditions.checkState(lastEquality == Equality.EQUAL, "Cannot extend composite since non equality control already set");
+        hasControl = true;
+        bb.put(control.toByte());
+    }
+    
+    public boolean hasControl() {
+        return hasControl;
+    }
+    
+    public ByteBuffer get() {
+        if (!hasControl) 
+            addControl(this.finalEquality);
+        
+        ByteBuffer ret = bb.duplicate();
+        ret.flip();
+        return ret;
+    }
+}


### PR DESCRIPTION
New EntityMapper for composite columns which uses a OneToMany
relationship between the parent entity, which has the Id for the row
key and child entities for each column with the value being a field of
the child.
