### PR TITLE
Possible fix to address my issue https://github.com/Netflix/astyanax/issues/322

### DIFF
--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/EntityMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/EntityMapper.java
@@ -25,6 +25,7 @@ import com.netflix.astyanax.ColumnListMutation;
 import com.netflix.astyanax.MutationBatch;
 import com.netflix.astyanax.model.ColumnFamily;
 import com.netflix.astyanax.model.ColumnList;
+import com.netflix.astyanax.serializers.SerializerTypeInferer;
 
 /**
  * utility class to map btw root Entity and cassandra data model
@@ -144,10 +145,13 @@ class EntityMapper<T, K> {
     	return retTtl;
     }
 
+    @VisibleForTesting
 	T constructEntity(K id, ColumnList<String> cl) {
 		try {
 		    T entity = clazz.newInstance();
-			idField.set(entity, id);
+            com.netflix.astyanax.Serializer<?> serializer = MappingUtils.getSerializerForField(idField);
+            com.netflix.astyanax.Serializer<K> valueSerializer = SerializerTypeInferer.getSerializer(id);
+            idField.set(entity, serializer.fromByteBuffer(valueSerializer.toByteBuffer(id)));
 			
 			for (com.netflix.astyanax.model.Column<String> column : cl) {
 			    List<String> name = Lists.newArrayList(StringUtils.split(column.getName(), "."));

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/CustomSerializerIdEntity.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/CustomSerializerIdEntity.java
@@ -1,0 +1,38 @@
+package com.netflix.astyanax.entitystore;
+
+import java.lang.String;
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import com.google.common.base.Optional;
+
+@Entity
+public class CustomSerializerIdEntity {
+    @SuppressWarnings("unused")
+    @Serializer(OptionalUUIDSerializer.class)
+    @Id
+    private Optional<UUID> id;
+
+    @SuppressWarnings("unused")
+    @Column(name="test_column")
+    private String testColumn;
+
+    public Optional<UUID> getId() {
+        return id;
+    }
+
+    public void setId(final Optional<UUID> id) {
+        this.id = id;
+    }
+
+    public String getTestColumn() {
+        return testColumn;
+    }
+
+    public void setTestColumn(final String testColumn) {
+        this.testColumn = testColumn;
+    }
+}

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/EntityMapperTest.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/EntityMapperTest.java
@@ -1,11 +1,24 @@
 package com.netflix.astyanax.entitystore;
 
+import java.lang.SuppressWarnings;
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 import java.util.Collection;
+import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.PersistenceException;
+
+import com.google.common.base.Optional;
+import com.netflix.astyanax.entitystore.Serializer;
+import com.netflix.astyanax.model.ColumnList;
+import com.netflix.astyanax.shallows.EmptyColumnList;
+import com.netflix.astyanax.serializers.AbstractSerializer;
+import com.netflix.astyanax.serializers.SerializerTypeInferer;
+import com.netflix.astyanax.serializers.UUIDSerializer;
+
 
 import junit.framework.Assert;
 
@@ -41,7 +54,7 @@ public class EntityMapperTest {
 		Assert.assertTrue(founduuid);
 	}
 
-	@Test(expected = IllegalArgumentException.class) 
+	@Test(expected = IllegalArgumentException.class)
 	public void missingEntityAnnotation() {
 		new EntityMapper<String, String>(String.class, null);
 	}
@@ -57,7 +70,7 @@ public class EntityMapperTest {
 		private long longPrimitive;
 	}
 
-	@Test(expected = IllegalArgumentException.class) 
+	@Test(expected = IllegalArgumentException.class)
 	public void invalidColumnName() {
 		new EntityMapper<InvalidColumnNameEntity, String>(InvalidColumnNameEntity.class, null);
 	}
@@ -76,4 +89,23 @@ public class EntityMapperTest {
 		// 3 cols: id, num, str
 		Assert.assertEquals(3, cols.size());
 	}
+
+    @Test
+    public void customSerializerOnIdColumn() {
+        EntityMapper<CustomSerializerIdEntity, UUID> entityMapper = new EntityMapper<CustomSerializerIdEntity, UUID>(CustomSerializerIdEntity.class, null);
+        UUID id = UUID.randomUUID();
+        ColumnList<String> columnList = new EmptyColumnList<String>();
+        try {
+            CustomSerializerIdEntity entity = entityMapper.constructEntity(id, columnList);
+            if (!entity.getId().isPresent()) {
+                Assert.fail("Optional Id is not present");
+            }
+
+            UUID theId = entity.getId().get();
+            Assert.assertEquals("actual UUID values are not equal", id, theId);
+        }
+        catch (Exception e) {
+            Assert.fail("Failed to construct becase: " + e.getMessage());
+        }
+    }
 }

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/OptionalUUIDSerializer.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/OptionalUUIDSerializer.java
@@ -1,0 +1,26 @@
+package com.netflix.astyanax.entitystore;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+import com.google.common.base.Optional;
+import com.netflix.astyanax.serializers.AbstractSerializer;
+import com.netflix.astyanax.serializers.UUIDSerializer;
+
+public class OptionalUUIDSerializer extends AbstractSerializer<Optional<UUID>> {
+    private static OptionalUUIDSerializer instance = new OptionalUUIDSerializer();
+
+    @Override
+    public ByteBuffer toByteBuffer(Optional<UUID> obj) {
+        return UUIDSerializer.get().toByteBuffer(obj.orNull());
+    }
+
+    @Override
+    public Optional<UUID> fromByteBuffer(ByteBuffer byteBuffer) {
+        return Optional.of(UUIDSerializer.get().fromByteBuffer(byteBuffer));
+    }
+
+    public static OptionalUUIDSerializer get() {
+        return instance;
+    }
+}


### PR DESCRIPTION
To fix issue https://github.com/Netflix/astyanax/issues/322 @Id annotated columns with custom serializers can now be saved and loaded with the entity persister
