### PR TITLE
Fix the recursive scanning of parent fields in AnnotatedCompositeSerializer

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AnnotatedCompositeSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AnnotatedCompositeSerializer.java
@@ -109,7 +109,7 @@ public class AnnotatedCompositeSerializer<T> extends AbstractSerializer<T> {
 		if (clazz.getDeclaredFields() != null && clazz.getDeclaredFields().length > 0) {
 			allFields.addAll(Arrays.asList(clazz.getDeclaredFields()));
 		}
-		if (recursively && clazz.getSuperclass() != null) {
+		if (recursively && clazz.getSuperclass() != null && !clazz.getSuperClass().equals(Object.class)) {
 			allFields.addAll(getFields(clazz.getSuperclass(), true));
 		}
 		return allFields;


### PR DESCRIPTION
AnnotatedCompositeSerializer has an option to scan the fields of the annotated class's superclasses to discover annotated fields.  However, the recursive call is only made if the current class has declared fields of its own, which can stop the scanning early without discovering annotated parent fields.  
