### PR TITLE
Modified CompositeEntityManager to treat each column as an entity instead of the OneToMany relationsihp between two pojos

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/MultiMutationBatchManager.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/MultiMutationBatchManager.java
@@ -1,0 +1,72 @@
+package com.netflix.astyanax;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.google.common.collect.Maps;
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.netflix.astyanax.model.ConsistencyLevel;
+
+/**
+ * Extension to mutation batch which allows for multiple 'named' mutation
+ * batches.  The purpose of this manager is to allow mutations to be executed
+ * in order of batch creation so that subsequent mutations aren't attempted 
+ * if there is a failure.
+ * 
+ * @author elandau
+ *
+ */
+public class MultiMutationBatchManager implements MutationBatchManager {
+    private final String DEFAULT_BATCH_NAME = "default";
+    
+    private final ThreadLocal<Map<String, MutationBatch>> batches = new ThreadLocal<Map<String, MutationBatch>>();
+    
+    private final Keyspace keyspace;
+    private final ConsistencyLevel cl;
+    
+    public MultiMutationBatchManager(Keyspace keyspace, ConsistencyLevel cl) {
+        this.keyspace = keyspace;
+        this.cl = cl;
+    }
+    
+    @Override
+    public MutationBatch getSharedMutationBatch() {
+        return getNamedMutationBatch(DEFAULT_BATCH_NAME);
+    }
+    
+    public MutationBatch getNamedMutationBatch(String name) {
+        Map<String, MutationBatch> mbs = batches.get();
+        if (mbs == null) {
+            mbs = Maps.newLinkedHashMap();
+            batches.set(mbs);
+        }
+        
+        MutationBatch mb = mbs.get(name);
+        if (mb == null) {
+            mb = getNewMutationBatch();
+            mbs.put(name, mb);
+        }
+        return mb;
+    }
+
+    @Override
+    public void commitSharedMutationBatch() throws ConnectionException {
+        Map<String, MutationBatch> mbs = batches.get();
+        if (mbs != null) {
+            for (Entry<String, MutationBatch> entry : mbs.entrySet()) {
+                entry.getValue().execute();
+            }
+            batches.remove();
+        }
+    }
+
+    @Override
+    public void discard() {
+        batches.remove();
+    }
+
+    @Override
+    public MutationBatch getNewMutationBatch() {
+        return keyspace.prepareMutationBatch().setConsistencyLevel(cl);
+    }
+}

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/MutationBatchManager.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/MutationBatchManager.java
@@ -1,0 +1,42 @@
+package com.netflix.astyanax;
+
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+
+/**
+ * The mutation manager enables different recipes or entity managers to use
+ * the same mutation for bulk operations.  In addition a mutation manager 
+ * can be used to implement write ahead semantics for 'atomic' mutations.
+ * 
+ * The mutation manager is expected to be thread safe such that all mutations
+ * in the same thread go to the same mutation batch.  This also means that
+ * getMutationBatch(), the mutations and the final commit() must occur within
+ * the same thread.
+ * 
+ * @author elandau
+ *
+ */
+public interface MutationBatchManager {
+    /**
+     * Get or create a new mutation batch.
+     * 
+     * @return
+     */
+    public MutationBatch getSharedMutationBatch();
+    
+    /**
+     * Get a one time mutation batch
+     * @return
+     */
+    public MutationBatch getNewMutationBatch();
+    
+    /**
+     * Commit all mutations on the batch
+     * @throws ConnectionException
+     */
+    public void commitSharedMutationBatch() throws ConnectionException ;
+    
+    /**
+     * Discard all mutations on the batch
+     */
+    public void discard();
+}

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/ThreadLocalMutationBatchManager.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/ThreadLocalMutationBatchManager.java
@@ -1,0 +1,61 @@
+package com.netflix.astyanax;
+
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.netflix.astyanax.model.ConsistencyLevel;
+import com.netflix.astyanax.retry.RetryPolicy;
+
+/**
+ * Simple mutation batch using thread local storage to keeps track of one 
+ * mutation per thread
+ * 
+ * @author elandau
+ *
+ */
+public class ThreadLocalMutationBatchManager implements MutationBatchManager {
+    private ThreadLocal<MutationBatch> batches = new ThreadLocal<MutationBatch>();
+    
+    private final Keyspace          keyspace;
+    private final ConsistencyLevel  cl;
+    private final RetryPolicy       retryPolicy;
+    
+    public ThreadLocalMutationBatchManager(Keyspace keyspace, ConsistencyLevel cl) {
+        this(keyspace, cl, null);
+    }
+    
+    public ThreadLocalMutationBatchManager(Keyspace keyspace, ConsistencyLevel cl, RetryPolicy retryPolicy) {
+        this.keyspace    = keyspace;
+        this.cl          = cl;
+        this.retryPolicy = retryPolicy;
+    }
+    
+    @Override
+    public MutationBatch getSharedMutationBatch() {
+        MutationBatch mb = batches.get();
+        if (mb == null) {
+            mb = keyspace.prepareMutationBatch().setConsistencyLevel(cl);
+            if (retryPolicy != null) 
+                mb.withRetryPolicy(retryPolicy);
+            batches.set(mb);
+        }
+        return mb;
+    }
+    
+    @Override
+    public MutationBatch getNewMutationBatch() {
+        return keyspace.prepareMutationBatch().setConsistencyLevel(cl);
+    }
+
+    @Override
+    public void commitSharedMutationBatch() throws ConnectionException {
+        MutationBatch mb = batches.get();
+        if (mb != null) {
+            mb.execute();
+            batches.remove();
+        }
+    }
+
+    @Override
+    public void discard() {
+        batches.remove();
+    }
+}

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/AbstractPreparedCqlQuery.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/AbstractPreparedCqlQuery.java
@@ -35,7 +35,7 @@ public abstract class AbstractPreparedCqlQuery<K, C> implements PreparedCqlQuery
 
     @Override
     public PreparedCqlQuery<K, C> withValues(List<ByteBuffer> values) {
-        values.addAll(values);
+        this.values.addAll(values);
         return this;
     }
 

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeColumnEntityMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeColumnEntityMapper.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.persistence.Column;
-import javax.persistence.Id;
 import javax.persistence.PersistenceException;
 
 import org.apache.commons.lang.StringUtils;
@@ -329,11 +328,17 @@ public class CompositeColumnEntityMapper {
             break;
         case GREATER_THAN:
         case GREATER_THAN_EQUALS:
-            start.add(bb, predicate.getOp());
+            if (mapper.isAscending())
+                start.add(bb, predicate.getOp());
+            else 
+                end.add(bb, predicate.getOp());
             break;
         case LESS_THAN:
         case LESS_THAN_EQUALS:
-            end.add(bb, predicate.getOp());
+            if (mapper.isAscending())
+                end.add(bb, predicate.getOp());
+            else 
+                start.add(bb, predicate.getOp());
             break;
         }
     }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityMapper.java
@@ -5,25 +5,36 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.PersistenceException;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.netflix.astyanax.ColumnListMutation;
 import com.netflix.astyanax.MutationBatch;
 import com.netflix.astyanax.model.ColumnFamily;
 import com.netflix.astyanax.model.ColumnList;
+import com.netflix.astyanax.model.Equality;
 import com.netflix.astyanax.query.ColumnPredicate;
 
 /**
- * The composite entity mapper expects an entity which has a single one to many
- * relationship with another entity representing the composite columns.  The child
- * entity will have an @Id field for each part of the composite followed by a single
+ * The composite entity mapper maps a Pojo to a composite column structure where
+ * the row key represents the Pojo ID, each @Column is a component of the composite
+ * and the final @Column is the column value.
  * @Column for the value.
  * 
  * @author elandau
@@ -33,21 +44,60 @@ import com.netflix.astyanax.query.ColumnPredicate;
  */
 public class CompositeEntityMapper<T, K> {
 
-    private final Class<T>              clazz;
-    private final Integer               ttl;
-    private final Method                ttlMethod;
-    private final FieldMapper<?>        idMapper;
-    private final String                entityName;
-    private final CompositeColumnEntityMapper embeddedEntityMapper;
+    /**
+     * Entity class
+     */
+    private final Class<T>          clazz;
+    
+    /**
+     * Default ttl
+     */
+    private final Integer           ttl;
+    
+    /**
+     * TTL supplier method
+     */
+    private final Method            ttlMethod;
+    
+    /**
+     * ID Field (same as row key)
+     */
+    final FieldMapper<?>            idMapper;
+    
+    /**
+     * TODO
+     */
+    private final String            entityName;
+
+    /**
+     * List of serializers for the composite parts
+     */
+    private List<FieldMapper<?>>    components = Lists.newArrayList();
+    
+    /**
+     * List of valid (i.e. existing) column names
+     */
+    private Set<String>             validNames = Sets.newHashSet();
+
+    /**
+     * Mapper for the value part of the entity
+     */
+    private FieldMapper<?>          valueMapper;
+    
+    /**
+     * Largest buffer size
+     */
+    private int                     bufferSize = 64;
 
     /**
      * 
      * @param clazz
+     * @param prefix 
      * @throws IllegalArgumentException 
      *      if clazz is NOT annotated with @Entity
      *      if column name contains illegal char (like dot)
      */
-    public CompositeEntityMapper(Class<T> clazz, Integer ttl) {
+    public CompositeEntityMapper(Class<T> clazz, Integer ttl, ByteBuffer prefix) {
         this.clazz = clazz;
         
         // clazz should be annotated with @Entity
@@ -92,30 +142,41 @@ public class CompositeEntityMapper<T, K> {
             if(idAnnotation != null) {
                 Preconditions.checkArgument(tempIdMapper == null, "there are multiple fields with @Id annotation");
                 field.setAccessible(true);
-                tempIdMapper = new FieldMapper(field);
+                tempIdMapper = new FieldMapper(field, prefix);
             }
             
-            // Should be a 'list'
-            OneToMany oneToManyAnnotation = field.getAnnotation(OneToMany.class);
-            if (oneToManyAnnotation != null) {
-                Preconditions.checkArgument(tempEmbeddedEntityMapper == null, "there are multiple fields with @OneToMany annotation");
-                tempEmbeddedEntityMapper = new CompositeColumnEntityMapper(field);
+            // Composite part or the value
+            Column columnAnnotation = field.getAnnotation(Column.class);
+            if (columnAnnotation != null) {
+                field.setAccessible(true);
+                FieldMapper fieldMapper = new FieldMapper(field);
+                components.add(fieldMapper);
+                validNames.add(fieldMapper.getName());
             }
         }
         
         Preconditions.checkNotNull(tempIdMapper, "there are no field with @Id annotation");
         idMapper    = tempIdMapper;
         
-        Preconditions.checkNotNull(tempEmbeddedEntityMapper, "there are no embedded entities using @OneToMany annotation");
-        embeddedEntityMapper    = tempEmbeddedEntityMapper;
+        Preconditions.checkNotNull(components.size() > 2, "there should be at least 2 component columns and a value");
+        
+        // Last one is always treated as the 'value'
+        valueMapper = components.remove(components.size() - 1);
     }
 
-    public void fillMutationBatch(MutationBatch mb, ColumnFamily<K, ByteBuffer> columnFamily, T entity) {
+    void fillMutationBatch(MutationBatch mb, ColumnFamily<K, ByteBuffer> columnFamily, T entity) {
         try {
             @SuppressWarnings("unchecked")
             ColumnListMutation<ByteBuffer> clm = mb.withRow(columnFamily, (K)idMapper.getValue(entity));
             clm.setDefaultTtl(getTtl(entity));
-            embeddedEntityMapper.fillMutationBatch(clm, entity);
+            try {
+                ByteBuffer columnName = toColumnName(entity);
+                ByteBuffer value      = valueMapper.toByteBuffer(entity);
+                clm.putColumn(columnName, value);
+            } catch(Exception e) {
+                throw new PersistenceException("failed to fill mutation batch", e);
+            }
+
         } catch(Exception e) {
             throw new PersistenceException("failed to fill mutation batch", e);
         }
@@ -123,14 +184,12 @@ public class CompositeEntityMapper<T, K> {
     
     void fillMutationBatchForDelete(MutationBatch mb, ColumnFamily<K, ByteBuffer> columnFamily, T entity) {
         try {
-            ByteBuffer id         = idMapper.toByteBuffer(entity);
             @SuppressWarnings("unchecked")
             ColumnListMutation<ByteBuffer> clm = mb.withRow(columnFamily, (K)idMapper.getValue(entity));
-            embeddedEntityMapper.fillMutationBatchForDelete(clm, entity);
+            clm.deleteColumn(toColumnName(entity));
         } catch(Exception e) {
             throw new PersistenceException("failed to fill mutation batch", e);
         }
-        
     }
     
     private Integer getTtl(T entity) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
@@ -144,52 +203,66 @@ public class CompositeEntityMapper<T, K> {
     }
     
     /**
+     * Return the column name byte buffer for this entity
+     * 
+     * @param obj
+     * @return
+     */
+    private ByteBuffer toColumnName(Object obj) {
+        SimpleCompositeBuilder composite = new SimpleCompositeBuilder(bufferSize, Equality.EQUAL);
+
+        // Iterate through each component and add to a CompositeType structure
+        for (FieldMapper<?> mapper : components) {
+            try {
+                composite.addWithoutControl(mapper.toByteBuffer(obj));
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return composite.get();
+    }
+    
+    /**
      * Construct an entity object from a row key and column list.
      * 
      * @param id
      * @param cl
      * @return
      */
-    public T constructEntity(K id, ColumnList<ByteBuffer> cl) {
+    T constructEntity(K id, com.netflix.astyanax.model.Column<ByteBuffer> column) {
         try {
             // First, construct the parent class and give it an id
             T entity = clazz.newInstance();
             idMapper.setValue(entity, id);
-            
-            // Now map to the OneToMany embedded entity field
-            embeddedEntityMapper.setField(entity, cl);
-            
+            setEntityFieldsFromColumnName(entity, column.getRawName().duplicate());
+            valueMapper.setField(entity, column.getByteBufferValue().duplicate());
             return entity;
         } catch(Exception e) {
             throw new PersistenceException("failed to construct entity", e);
         }
     }
     
-    public T constructEntityFromCql(T candidateEntity, ColumnList<ByteBuffer> cl) {
+    T constructEntityFromCql(ColumnList<ByteBuffer> cl) {
         try {
-            K id = (K) idMapper.fromByteBuffer(Iterables.getFirst(cl, null).getByteBufferValue());
-            T entity;
-            if (candidateEntity != null && idMapper.getValue(candidateEntity).equals(id)) {
-                entity = candidateEntity;
-            }
-            else {
-                entity = clazz.newInstance();
-            }
+            T entity = clazz.newInstance();
             
             // First, construct the parent class and give it an id
+            K id = (K) idMapper.fromByteBuffer(Iterables.getFirst(cl, null).getByteBufferValue());
             idMapper.setValue(entity, id);
             
-            // Now map to the OneToMany embedded entity field
-            embeddedEntityMapper.setFieldFromCql(entity, cl);
+            Iterator<com.netflix.astyanax.model.Column<ByteBuffer>> columnIter = cl.iterator();
+            columnIter.next();
             
+            for (FieldMapper<?> component : components) {
+                component.setField(entity, columnIter.next().getByteBufferValue());
+            }
+                    
+            valueMapper.setField(entity, columnIter.next().getByteBufferValue());
             return entity;
         } catch(Exception e) {
             throw new PersistenceException("failed to construct entity", e);
         }
-    }
-    
-    public String getComparatorType() {
-        return embeddedEntityMapper.getComparatorType();
     }
     
     @SuppressWarnings("unchecked")
@@ -214,12 +287,141 @@ public class CompositeEntityMapper<T, K> {
     public String getKeyType() {
         return idMapper.getSerializer().getComparatorType().getClassName();
     }
+
+    /**
+     * Return an object from the column
+     * 
+     * @param cl
+     * @return
+     */
+    Object fromColumn(K id, com.netflix.astyanax.model.Column<ByteBuffer> c) {
+        try {
+            // Allocate a new entity
+            Object entity         = clazz.newInstance();
+            
+            idMapper.setValue(entity, id);
+            setEntityFieldsFromColumnName(entity, c.getRawName().duplicate());
+            valueMapper.setField(entity, c.getByteBufferValue().duplicate());
+            return entity;
+        } catch(Exception e) {
+            throw new PersistenceException("failed to construct entity", e);
+        }
+    }
     
-    public String getValueType() {
-        return embeddedEntityMapper.getValueType();
+    /**
+     * 
+     * @param entity
+     * @param columnName
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     */
+    void setEntityFieldsFromColumnName(Object entity, ByteBuffer columnName) throws IllegalArgumentException, IllegalAccessException {
+        // Iterate through components in order and set fields
+        for (FieldMapper<?> component : components) {
+            ByteBuffer data = getWithShortLength(columnName);
+            if (data != null) {
+                if (data.remaining() > 0) {
+                    component.setField(entity, data);
+                }
+                byte end_of_component = columnName.get();
+                if (end_of_component != Equality.EQUAL.toByte()) {
+                    throw new RuntimeException("Invalid composite column.  Expected END_OF_COMPONENT.");
+                }
+            }
+            else {
+                throw new RuntimeException("Missing component data in composite type");
+            }
+        }
     }
 
-    public ByteBuffer[] getQueryEndpoints(Collection<ColumnPredicate> predicates) {
-        return this.embeddedEntityMapper.getQueryEndpoints(predicates);
+    /**
+     * Return the cassandra comparator type for this composite structure
+     * @return
+     */
+    public String getComparatorType() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CompositeType(");
+        sb.append(StringUtils.join(
+            Collections2.transform(components, new Function<FieldMapper<?>, String>() {
+                public String apply(FieldMapper<?> input) {
+                    return input.serializer.getComparatorType().getClassName();
+                }
+            }),
+            ","));
+        sb.append(")");
+        return sb.toString();
+    }
+
+    
+    public static int getShortLength(ByteBuffer bb) {
+        int length = (bb.get() & 0xFF) << 8;
+        return length | (bb.get() & 0xFF);
+    }
+
+    public static ByteBuffer getWithShortLength(ByteBuffer bb) {
+        int length = getShortLength(bb);
+        return getBytes(bb, length);
+    }
+
+    public static ByteBuffer getBytes(ByteBuffer bb, int length) {
+        ByteBuffer copy = bb.duplicate();
+        copy.limit(copy.position() + length);
+        bb.position(bb.position() + length);
+        return copy;
+    }
+
+    String getValueType() {
+        return valueMapper.getSerializer().getComparatorType().getClassName();
+    }
+
+    ByteBuffer[] getQueryEndpoints(Collection<ColumnPredicate> predicates) {
+        // Convert to multimap for easy lookup
+        ArrayListMultimap<Object, ColumnPredicate> lookup = ArrayListMultimap.create();
+        for (ColumnPredicate predicate : predicates) {
+            Preconditions.checkArgument(validNames.contains(predicate.getName()), "Field '" + predicate.getName() + "' does not exist in the entity " + clazz.getCanonicalName());
+            lookup.put(predicate.getName(), predicate);
+        }
+        
+        SimpleCompositeBuilder start = new SimpleCompositeBuilder(bufferSize, Equality.GREATER_THAN_EQUALS);
+        SimpleCompositeBuilder end   = new SimpleCompositeBuilder(bufferSize, Equality.LESS_THAN_EQUALS);
+
+        // Iterate through components in order while applying predicate to 'start' and 'end'
+        for (FieldMapper<?> mapper : components) {
+            for (ColumnPredicate p : lookup.get(mapper.getName())) {
+                try {
+                    applyPredicate(mapper, start, end, p);
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(String.format("Failed to serialize predicate '%s'", p.toString()), e);
+                }
+            }
+        }
+        
+        return new ByteBuffer[]{start.get(), end.get()};
+    }
+    
+    void applyPredicate(FieldMapper<?> mapper, SimpleCompositeBuilder start, SimpleCompositeBuilder end, ColumnPredicate predicate) {
+        ByteBuffer bb = mapper.valueToByteBuffer(predicate.getValue());
+        
+        switch (predicate.getOp()) {
+        case EQUAL:
+            start.addWithoutControl(bb);
+            end.addWithoutControl(bb);
+            break;
+        case GREATER_THAN:
+        case GREATER_THAN_EQUALS:
+            if (mapper.isAscending())
+                start.add(bb, predicate.getOp());
+            else 
+                end.add(bb, predicate.getOp());
+            break;
+        case LESS_THAN:
+        case LESS_THAN_EQUALS:
+            if (mapper.isAscending())
+                end.add(bb, predicate.getOp());
+            else 
+                start.add(bb, predicate.getOp());
+            break;
+        }
     }
 }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/DefaultEntityManager.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/DefaultEntityManager.java
@@ -174,6 +174,10 @@ public class DefaultEntityManager<T, K> implements EntityManager<T, K> {
 			return new DefaultEntityManager<T, K>(this);
 		}
 	}
+	
+	public static <T,K> Builder<T,K> builder() {
+	    return new Builder<T,K>();
+	}
 
 	//////////////////////////////////////////////////////////////////
 	// private members
@@ -279,11 +283,6 @@ public class DefaultEntityManager<T, K> implements EntityManager<T, K> {
             @Override
             public synchronized Boolean apply(T entity) {
                 entities.add(entity);
-                try {
-                    lifecycleHandler.onPostLoad(entity);
-                } catch (Exception e) {
-                    // TODO
-                }
                 return true;
             }
         });
@@ -457,6 +456,8 @@ public class DefaultEntityManager<T, K> implements EntityManager<T, K> {
         try {
             keyspace.createColumnFamily(this.columnFamily, options);
         } catch (ConnectionException e) {
+            if (e.getMessage().contains("already exist")) 
+                return;
             throw new PersistenceException("Unable to create column family " + this.columnFamily.getName(), e);
         }
     }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/NativeQuery.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/NativeQuery.java
@@ -2,6 +2,7 @@ package com.netflix.astyanax.entitystore;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.collect.Lists;
 import com.netflix.astyanax.model.Equality;
@@ -21,7 +22,7 @@ public abstract class NativeQuery<T, K> {
     protected List<K>                 ids = Lists.newArrayList();
     protected Collection<Object>      columnNames;
     protected List<ColumnPredicate>   predicates;
-    protected Integer                 columnLimit = null;
+    protected int                     columnLimit = Integer.MAX_VALUE;
     
     /**
      * Refine query for row key
@@ -119,4 +120,22 @@ public abstract class NativeQuery<T, K> {
      * @throws Exception
      */
     public abstract Collection<T> getResultSet() throws Exception;
+    
+    /**
+     * Get the result set as a mapping of the id field to a collection of entities. This
+     * is useful for a multi-get scenario where it is desirable to group all the 'entities'
+     * within a row.
+     * 
+     * @return
+     * @throws Exception
+     */
+    public abstract Map<K, Collection<T>> getResultSetById() throws Exception;
+
+    /**
+     * Get the column count for each id in the query without sending data back
+     * to the client.
+     * @return
+     * @throws Excerption
+     */
+    public abstract Map<K, Integer> getResultSetCounts() throws Exception;
 }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SimpleCompositeBuilder.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SimpleCompositeBuilder.java
@@ -33,9 +33,6 @@ public class SimpleCompositeBuilder {
     public void addWithoutControl(ByteBuffer cb) {
         Preconditions.checkState(lastEquality == Equality.EQUAL, "Cannot extend composite since non equality control already set");
         
-        if (!hasControl)
-            addControl(Equality.EQUAL);
-        
         if (cb == null) {
             cb = ByteBuffer.allocate(0);
         }
@@ -48,6 +45,15 @@ public class SimpleCompositeBuilder {
             temp.put(bb);
             bb = temp;
         }
+        
+        if (!hasControl) {
+            addControl(Equality.EQUAL);
+        }
+        else if (bb.position() > 0) {
+            bb.position(bb.position() - 1);
+            bb.put(Equality.EQUAL.toByte());
+        }
+
         // Write the data: <length><data>
         bb.putShort((short) cb.remaining());
         bb.put(cb.slice());

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/TTL.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/TTL.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Documented
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TTL {
 

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/CompositeEntityManagerTest.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/CompositeEntityManagerTest.java
@@ -42,73 +42,27 @@ public class CompositeEntityManagerTest {
     @Entity
     public static class TestEntity {
         public TestEntity() {
-            
         }
         
-        public TestEntity(String rowKey, List<TestEntityChild> children) {
-            super();
-            this.rowKey   = rowKey;
-            this.children = children;
-        }
-
-        @Id     
-        private String rowKey;      // This will be the row key
-        
-        @OneToMany
-        private List<TestEntityChild> children;
-
-        public TestEntity addChild(TestEntityChild entity) {
-            if (children == null)
-                children = Lists.newArrayList();
-            children.add(entity);
-            return this;
-        }
-        
-        public String getRowKey() {
-            return rowKey;
-        }
-
-        public TestEntity setRowKey(String rowKey) {
-            this.rowKey = rowKey;
-            return this;
-        }
-
-        public List<TestEntityChild> getChildren() {
-            return children;
-        }
-
-        public TestEntity setChildren(List<TestEntityChild> children) {
-            this.children = children;
-            return this;
-        }
-
-        @Override
-        public String toString() {
-            return "TestEntity [rowKey=" + rowKey + ", children=" + children
-                    + "]";
-        }
-        
-    }
-    
-    @Entity
-    public static class TestEntityChild {
-        public TestEntityChild() {
-        }
-        
-        public TestEntityChild(String part1, Long part2, Long value) {
+        public TestEntity(String rowKey, String part1, Long part2, Long value) {
             super();
             this.part1 = part1;
             this.part2 = part2;
             this.value = value;
+            this.rowKey = rowKey;
         }
-
+        
+        @Id     String rowKey;      // This will be the row key
         @Column String part1;       // This will be the first part of the composite
         @Column Long   part2;       // This will be the second part of the composite
         @Column Long   value;       // This will be the value of the composite
         
         @Override
         public String toString() {
-            return "TestEntityChild [part1=" + part1 + ", part2=" + part2
+            return "TestEntityChild ["
+                    +   "key="   + rowKey 
+                    + ", part1=" + part1 
+                    + ", part2=" + part2
                     + ", value=" + value + "]";
         }
     }
@@ -178,21 +132,26 @@ public class CompositeEntityManagerTest {
         
         manager = CompositeEntityManager.<TestEntity, String>builder()
                     .withKeyspace(keyspace)
-                    .withColumnFamily("TestEntity")
+                    .withColumnFamily("testentity")
                     .withEntityType(TestEntity.class)
+                    .withVerboseTracing(true)
                     .build();
         
         manager.createStorage(null);
 
-        List<TestEntityChild> children = Lists.newArrayList();
+        List<TestEntity> children = Lists.newArrayList();
         
         for (long i = 0; i < 10; i++) {
-            children.add(new TestEntityChild("a", i, i*i));
-            children.add(new TestEntityChild("b", i, i*i));
+            children.add(new TestEntity("A", "a", i, i*i));
+            children.add(new TestEntity("A", "b", i, i*i));
+            children.add(new TestEntity("B", "a", i, i*i));
+            children.add(new TestEntity("B", "b", i, i*i));
         }
         
-        manager.put(new TestEntity("A", children));
-        manager.put(new TestEntity("B", children));
+        manager.put(children);
+        
+        // Read back all rows and log
+        logResultSet(manager.getAll(), "ALL: ");
     }
 
     @Test
@@ -201,24 +160,21 @@ public class CompositeEntityManagerTest {
         Collection<TestEntity> entitiesNative;
 
         // Simple row query
-        TestEntity entity = manager.get("A");
-        LOG.info("Result : " + entity);
-
         entitiesNative = manager.createNativeQuery()
                 .whereId().in("A")
                 .getResultSet();
-        Assert.assertEquals(entitiesNative.size(), 1);
+        Assert.assertEquals(20, entitiesNative.size());
         LOG.info("NATIVE: " + entitiesNative);
         
         // Multi row query
         cqlEntities = manager.find("SELECT * from TestEntity WHERE KEY IN ('A', 'B')");
-        Assert.assertEquals(2,  cqlEntities.size());
+        Assert.assertEquals(40,  cqlEntities.size());
         
         entitiesNative = manager.createNativeQuery()
                 .whereId().in("A", "B")
                 .getResultSet();
         LOG.info("NATIVE: " + entitiesNative);
-        Assert.assertEquals(entitiesNative.size(), 2);
+        Assert.assertEquals(40, entitiesNative.size());
         
         // Simple prefix
         entitiesNative = manager.createNativeQuery()
@@ -226,20 +182,18 @@ public class CompositeEntityManagerTest {
                 .whereColumn("part1").equal("a")
                 .getResultSet();
         LOG.info("NATIVE: " + entitiesNative);
-        Assert.assertEquals(entitiesNative.size(), 1);
+        Assert.assertEquals(10, entitiesNative.size());
         
         cqlEntities = manager.find("SELECT * from TestEntity WHERE KEY = 'A' AND column1='b' AND column2>=5 AND column2<8");
-        Assert.assertEquals(1,  cqlEntities.size());
-        Assert.assertEquals(3,  Iterables.getFirst(cqlEntities, null).children.size());
+        Assert.assertEquals(3,  cqlEntities.size());
         LOG.info(cqlEntities.toString());
         
-        manager.remove(new TestEntity().setRowKey("A").addChild(new TestEntityChild("b", 5L, null)));
+        manager.remove(new TestEntity("A", "b", 5L, null));
         cqlEntities = manager.find("SELECT * from TestEntity WHERE KEY = 'A' AND column1='b' AND column2>=5 AND column2<8");
-        Assert.assertEquals(1,  cqlEntities.size());
-        Assert.assertEquals(2,  Iterables.getFirst(cqlEntities, null).children.size());
+        Assert.assertEquals(2,  cqlEntities.size());
         LOG.info(cqlEntities.toString());
         
-        manager.remove(new TestEntity().setRowKey("A"));
+        manager.delete("A");
         cqlEntities = manager.find("SELECT * from TestEntity WHERE KEY = 'A' AND column1='b' AND column2>=5 AND column2<8");
         Assert.assertEquals(0,  cqlEntities.size());
     }
@@ -256,8 +210,25 @@ public class CompositeEntityManagerTest {
                 .getResultSet();
 
         LOG.info("NATIVE: " + entitiesNative.toString());
-        Assert.assertEquals(entitiesNative.size(), 1);
+        Assert.assertEquals(3, entitiesNative.size());
     }
+    
+//  ... Not sure this use case makes sense since cassandra will end up returning
+//  columns with part2 greater than 8 but less than b
+//    @Test
+//    public void testQueryComplexRange() throws Exception {
+//        Collection<TestEntity> entitiesNative;
+//
+//        entitiesNative = manager.createNativeQuery()
+//                .whereId().in("B")
+//                .whereColumn("part1").lessThan("b")
+//                .whereColumn("part2").lessThan(8L)
+//                .getResultSet();
+//
+//        LOG.info("NATIVE: " + entitiesNative.toString());
+//        logResultSet(manager.getAll(), "COMPLEX RANGE: ");
+//        Assert.assertEquals(2, entitiesNative.size());
+//    }
     
     @Test
     public void testBadFieldName() throws Exception {
@@ -270,7 +241,15 @@ public class CompositeEntityManagerTest {
             Assert.fail();
         }
         catch (Exception e) {
-            e.printStackTrace();
+            LOG.info(e.getMessage(), e);
+        }
+    }
+    
+    private static void logResultSet(List<TestEntity> result, String prefix) {
+        // Read back all rows and log
+        List<TestEntity> all = manager.getAll();
+        for (TestEntity entity : all) {
+            LOG.info(prefix + entity.toString());
         }
     }
 }

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftMutationBatchImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftMutationBatchImpl.java
@@ -136,6 +136,9 @@ public abstract class AbstractThriftMutationBatchImpl implements MutationBatch {
             timestamp = clock.getCurrentTime();
 
         ByteBuffer bbKey = columnFamily.getKeySerializer().toByteBuffer(rowKey);
+        if (!bbKey.hasRemaining()) {
+            throw new RuntimeException("Row key cannot be empty");
+        }
         
         KeyAndColumnFamily kacf = new KeyAndColumnFamily(columnFamily.getName(), bbKey);
         ColumnListMutation<C> clm = (ColumnListMutation<C>) rowLookup.get(kacf);

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftAllRowsQueryImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftAllRowsQueryImpl.java
@@ -94,7 +94,6 @@ public class ThriftAllRowsQueryImpl<K, C> implements AllRowsQuery<K, C> {
                         }, query.retry).getResult();
             }
             catch (ConnectionException e) {
-                e.printStackTrace();
                 // Let exception callback handle this exception. If it
                 // returns false then
                 // we return an empty result which the iterator's

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftColumnFamilyMutationImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftColumnFamilyMutationImpl.java
@@ -18,6 +18,7 @@ package com.netflix.astyanax.thrift;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import com.netflix.astyanax.AbstractColumnListMutation;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
@@ -55,10 +56,20 @@ public class ThriftColumnFamilyMutationImpl<C> extends AbstractColumnListMutatio
 
     @Override
     public <V> ColumnListMutation<C> putColumn(C columnName, V value, Serializer<V> valueSerializer, Integer ttl) {
+        Preconditions.checkNotNull(columnName, "Column name cannot be null");
+        
         // 1. Set up the column with all the data
         Column column = new Column();
         column.setName(columnSerializer.toByteBuffer(columnName));
-        column.setValue(valueSerializer.toByteBuffer(value));
+        if (column.getName().length == 0) {
+            throw new RuntimeException("Column name cannot be empty");
+        }
+        
+        if (value == null) 
+            column.setValue(ThriftUtils.EMPTY_BYTE_BUFFER);
+        else 
+            column.setValue(valueSerializer.toByteBuffer(value));
+        
         column.setTimestamp(timestamp);
         if (ttl != null) {
             // Treat TTL of 0 or -1 as no TTL
@@ -78,8 +89,14 @@ public class ThriftColumnFamilyMutationImpl<C> extends AbstractColumnListMutatio
 
     @Override
     public ColumnListMutation<C> putEmptyColumn(C columnName, Integer ttl) {
+        Preconditions.checkNotNull(columnName, "Column name cannot be null");
+        
         Column column = new Column();
         column.setName(columnSerializer.toByteBuffer(columnName));
+        if (column.getName().length == 0) {
+            throw new RuntimeException("Column name cannot be empty");
+        }
+        
         column.setValue(ThriftUtils.EMPTY_BYTE_BUFFER);
         column.setTimestamp(timestamp);
         if (ttl != null) {
@@ -111,9 +128,14 @@ public class ThriftColumnFamilyMutationImpl<C> extends AbstractColumnListMutatio
 
     @Override
     public ColumnListMutation<C> incrementCounterColumn(C columnName, long amount) {
+        Preconditions.checkNotNull(columnName, "Column name cannot be null");
+        
         // 1. Set up the column with all the data
         CounterColumn column = new CounterColumn();
         column.setName(columnSerializer.toByteBuffer(columnName));
+        if (column.getName().length == 0) {
+            throw new RuntimeException("Column name cannot be empty");
+        }
         column.setValue(amount);
 
         // 2. Create a mutation and append to the mutation list.
@@ -125,6 +147,8 @@ public class ThriftColumnFamilyMutationImpl<C> extends AbstractColumnListMutatio
 
     @Override
     public ColumnListMutation<C> deleteColumn(C columnName) {
+        Preconditions.checkNotNull(columnName, "Column name cannot be null");
+        
         // Create a reusable predicate for deleting columns and insert only once
         if (null == lastDeletion || lastDeletion.getTimestamp() != timestamp) {
             lastDeletion = new Deletion().setPredicate(new SlicePredicate()).setTimestamp(timestamp);
@@ -132,6 +156,10 @@ public class ThriftColumnFamilyMutationImpl<C> extends AbstractColumnListMutatio
         }
         
         ByteBuffer bb = this.columnSerializer.toByteBuffer(columnName);
+        if (!bb.hasRemaining()) {
+            throw new RuntimeException("Column name cannot be empty");
+        }
+
         lastDeletion.getPredicate().addToColumn_names(bb);
         return this;
     }

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
@@ -871,7 +871,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
         KeyspaceDefinition ksDef = this.describeKeyspace();
         ColumnFamilyDefinition cfDef = ksDef.getColumnFamily(columnFamily);
         if (cfDef == null)
-            throw new NotFoundException(String.format("Column family '%s' in keyspace '%s' not found", getKeyspaceName(), columnFamily));
+            throw new NotFoundException(String.format("Column family '%s' in keyspace '%s' not found", columnFamily, getKeyspaceName()));
         
         Properties props = new Properties();
         ThriftColumnFamilyDefinitionImpl thriftCfDef = (ThriftColumnFamilyDefinitionImpl)cfDef;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftUtils.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftUtils.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.thrift.ColumnDef;
 import org.apache.cassandra.thrift.SliceRange;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
+import org.apache.thrift.TEnum;
 import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.meta_data.FieldMetaData;
 import org.slf4j.Logger;
@@ -213,9 +214,7 @@ public class ThriftUtils {
                 case ENUM   : {
                     org.apache.thrift.meta_data.EnumMetaData meta = (org.apache.thrift.meta_data.EnumMetaData)f.getValue().valueMetaData;
                     Object e = meta.enumClass;
-                    if (e instanceof Enum) {
-                        entity.setFieldValue(f.getKey(), Enum.valueOf((Class<Enum>) e, (String)value));
-                    }
+                    entity.setFieldValue(f.getKey(), Enum.valueOf((Class<Enum>) e, (String)value));
                     break;
                 }
                 case MAP    : {

--- a/astyanax-thrift/src/test/java/com/netflix/astyanax/thrift/ThriftKeyspaceImplTest.java
+++ b/astyanax-thrift/src/test/java/com/netflix/astyanax/thrift/ThriftKeyspaceImplTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Random;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -504,7 +505,8 @@ public class ThriftKeyspaceImplTest {
         KsDef def2 = ThriftUtils.getThriftObjectFromProperties(KsDef.class, props);
         Properties props2 = ThriftUtils.getPropertiesFromThrift(def2);
 
-        LOG.info("Props2:" + props2);
+        LOG.info("Props1:" + new TreeMap<Object, Object>(props));
+        LOG.info("Props2:" + new TreeMap<Object, Object>(props2));
         MapDifference<Object, Object> diff = Maps.difference(props,  props2);
         LOG.info("Not copied : " + diff.entriesOnlyOnLeft());
         LOG.info("Added      : " + diff.entriesOnlyOnRight());
@@ -1658,6 +1660,64 @@ public class ThriftKeyspaceImplTest {
         }
     }
 
+    @Test
+    public void testEmptyRowKey() {
+        try {
+            keyspace.prepareMutationBatch().withRow(CF_STANDARD1, "");
+            Assert.fail();
+        }
+        catch (Exception e) {
+            LOG.info(e.getMessage());
+        }
+        
+        try {
+            keyspace.prepareMutationBatch().withRow(CF_STANDARD1, null);
+            Assert.fail();
+        }
+        catch (Exception e) {
+            LOG.info(e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testEmptyColumn() {
+        ColumnListMutation<String> mutation = keyspace.prepareMutationBatch().withRow(CF_STANDARD1, "ABC");
+        
+        try {
+            mutation.putColumn(null,  1L);
+            Assert.fail();
+        }
+        catch (Exception e) {
+            LOG.info(e.getMessage());
+        }
+        
+        try {
+            mutation.putColumn("",  1L);
+            Assert.fail();
+        }
+        catch (Exception e) {
+            LOG.info(e.getMessage());
+        }
+
+        try {
+            mutation.deleteColumn("");
+            Assert.fail();
+        }
+        catch (Exception e) {
+            LOG.info(e.getMessage());
+        }
+        
+        try {
+            mutation.deleteColumn(null);
+            Assert.fail();
+        }
+        catch (Exception e) {
+            LOG.info(e.getMessage());
+        }
+        
+
+    }
+    
     @Test
     public void testCql() {
         try {


### PR DESCRIPTION
1.  Fix prepared CQL query not accepting values
2.  Modified CompositeEntityManager to treat each column as an entity instead of the OneToMany relationsihp between two pojos.  This makes deleting individual columns much more straightforward.
3. Fix double onPostLoad call when getting all rows
