### PR TITLE
Properly use ConnectionPoolMonitor callbacks for connection borrowing for TokenAware/RoundRobin connection pools

### DIFF
--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolMonitor.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolMonitor.java
@@ -47,7 +47,7 @@ public interface ConnectionPoolMonitor {
      * Succeeded in executing an operation
      * 
      * @param host
-     * @param latency
+     * @param latency, in nanoseconds
      */
     void incOperationSuccess(Host host, long latency);
 
@@ -86,7 +86,7 @@ public interface ConnectionPoolMonitor {
      * @param host
      *            Host from which the connection was borrowed
      * @param delay
-     *            Time spent in the connection pool borrowing the connection
+     *            Time spent (in milliseconds) in the connection pool borrowing the connection
      */
     void incConnectionBorrowed(Host host, long delay);
 

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractExecuteWithFailoverImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractExecuteWithFailoverImpl.java
@@ -81,7 +81,7 @@ public abstract class AbstractExecuteWithFailoverImpl<CL, R> implements ExecuteW
 		else 
 			return Host.NO_HOST;
 	}
-	
+
 	/**
 	 * @return {@link HostConnectionPool}
 	 */
@@ -139,12 +139,17 @@ public abstract class AbstractExecuteWithFailoverImpl<CL, R> implements ExecuteW
         }
     }
 
-	protected void releaseConnection() {
+    protected ConnectionPoolMonitor getMonitor() {
+        return monitor;
+    }
+
+    protected void releaseConnection() {
         if (connection != null) {
-	    	connection.getHostConnectionPool().returnConnection(connection);
-	        connection = null;
-	    }
-	}
+            connection.getHostConnectionPool().returnConnection(connection);
+            monitor.incConnectionReturned(connection.getHost());
+            connection = null;
+        }
+    }
     
     private void informException(ConnectionException connectionException) throws ConnectionException {
         connectionException

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/RoundRobinExecuteWithFailover.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/RoundRobinExecuteWithFailover.java
@@ -80,8 +80,19 @@ public class RoundRobinExecuteWithFailover<CL, R> extends AbstractExecuteWithFai
 
     @Override
     public Connection<CL> borrowConnection(Operation<CL, R> operation) throws ConnectionException {
-        pool = pools.get(getNextHostIndex());
-        return pool.borrowConnection(waitDelta * waitMultiplier);
+        Connection<CL> connection = null;
+        long startTime = System.currentTimeMillis();
+
+        try {
+            pool = pools.get(getNextHostIndex());
+            connection = pool.borrowConnection(waitDelta * waitMultiplier);
+            return connection;
+        }
+        finally {
+            if (connection != null) {
+                getMonitor().incConnectionBorrowed(connection.getHost(), System.currentTimeMillis() - startTime);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Make sure that ConnectionPoolMonitor.incConnectionBorrowed() and incConnectionReturned() are invoked properly for TokenAware and RoundRobin connection pool impls.

Update Javadoc comments in ConnectionPoolMonitor to explicitly mention the time units for incOperationSuccess() and incConnectionBorrowed().
