### PR TITLE
allow fat jar creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ project(':astyanax-core') {
     }
     jar {
         dependsOn configurations.runtime
+        baseName = 'astyanax-all'
         from { configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) } }
     }
 }


### PR DESCRIPTION
This allows fat jars to be created by invoking `./gradlew jar` in the project root.
