### PR TITLE
Allow ColumnFamilyQuery#setConsistencyLevel to carry over to CqlQuery instances which it constructs.

### DIFF
--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftCqlQuery.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftCqlQuery.java
@@ -33,6 +33,7 @@ public abstract class AbstractThriftCqlQuery<K,C> implements CqlQuery<K,C> {
     AbstractThriftCqlQuery(ThriftColumnFamilyQueryImpl<K,C> cfQuery, String cql) {
         this.cfQuery = cfQuery;
         this.cql = cql;
+        this.cl = cfQuery.consistencyLevel;
     }
     
     @Override


### PR DESCRIPTION
Currently the following example code:

``` java
final ColumnFamily<SomeKey, SomeValue> cf = getColumnFamily();
final String cql = getCql();
final CqlQuery<SomeKey, SomeValue> cqlQuery = getKeyspace().prepareQuery(cf)
    .setConsistencyLevel(ConsistencyLevel.CL_QUORUM).withCql(cql);
```

Will result in a CqlQuery that has the ConsistencyLevel still set to CL_ONE (the default in AbstractThriftCqlQuery). This pull-request fixes that by carrying over the CL from the ThriftColumnFamilyQueryImpl instance it is created with.
