### PR TITLE
Fixed rack equality check in describeRing()

### DIFF
--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
@@ -200,7 +200,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                                 if (dc != null && !ed.getDatacenter().equals(dc)) {
                                     continue;
                                 }
-                                else if (rack != null && !ed.getRack().equals(dc)) {
+                                else if (rack != null && !ed.getRack().equals(rack)) {
                                     continue;
                                 }
                                 else {


### PR DESCRIPTION
The equality check should compare `ed.getRack()` to `rack`, not `dc`.
