### PR TITLE
Using original TBinaryProtocol from Thrift Library

### DIFF
--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftMutationBatchImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftMutationBatchImpl.java
@@ -29,7 +29,7 @@ import com.google.common.collect.Maps.EntryTransformer;
 
 import org.apache.cassandra.thrift.Cassandra.batch_mutate_args;
 import org.apache.cassandra.thrift.Mutation;
-import org.apache.cassandra.thrift.TBinaryProtocol;
+import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TIOStreamTransport;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftSyncConnectionFactoryImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftSyncConnectionFactoryImpl.java
@@ -40,7 +40,7 @@ import com.netflix.astyanax.connectionpool.impl.SimpleRateLimiterImpl;
 
 import org.apache.cassandra.thrift.AuthenticationRequest;
 import org.apache.cassandra.thrift.Cassandra;
-import org.apache.cassandra.thrift.TBinaryProtocol;
+import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSSLTransportFactory;
 import org.apache.thrift.transport.TSSLTransportFactory.TSSLTransportParameters;


### PR DESCRIPTION
Changing import statements so that we use TBinaryProtocol directly from org.apache.thrift library rather than depending on org.apache.cassandra.thrift. 

org.apache.cassandra.thrift.TBinaryProtocol was supposed to be used for all pre-thrift 0.7 based libraries.  
Now we are using thrift 0.7 as a dependency in a6x, hence it should be safe to use thrift version directly.
