### PR TITLE
Update MapSerializer.java

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/MapSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/MapSerializer.java
@@ -34,11 +34,13 @@ public class MapSerializer<K, V> extends AbstractSerializer<Map<K, V>> {
     public Map<K, V> fromByteBuffer(ByteBuffer arg0) {
         if (arg0 == null) return null;
             ByteBuffer dup = arg0.duplicate();
-            return myMap.compose(dup);
+            return myMap.getSerializer().deserialize(dup);
+            //return myMap.compose(dup);
             }
 
     @Override
     public ByteBuffer toByteBuffer(Map<K, V> arg0) {
-        return arg0 == null ? null : myMap.decompose(arg0);
+        return arg0 == null ? null : myMap.getSerializer().serialize(arg0);
+        //return arg0 == null ? null : myMap.decompose(arg0);
     }
 }


### PR DESCRIPTION
I could not retrieve the map entries for a cql3 created map entry in a table.  Error was NoSuchMethodError for MapType compose in the org.apache.cassandra.db.marshal.MapType.
