### PR TITLE
Custom type of Set and Map serialization

### DIFF
--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MappingUtils.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MappingUtils.java
@@ -2,6 +2,9 @@ package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.Map;
+import java.util.Set;
 
 import javax.persistence.Entity;
 
@@ -10,36 +13,65 @@ import org.apache.commons.lang.StringUtils;
 import com.netflix.astyanax.serializers.SerializerTypeInferer;
 
 public class MappingUtils {
+	
     static com.netflix.astyanax.Serializer<?> getSerializerForField(Field field) {
         com.netflix.astyanax.Serializer<?> serializer = null;
+        
         // check if there is explicit @Serializer annotation first
-        Serializer serializerAnnotation = field.getAnnotation(Serializer.class);
-        if(serializerAnnotation != null) {
-            final Class<?> serializerClazz = serializerAnnotation.value();
-            // check type
-            if(!(com.netflix.astyanax.Serializer.class.isAssignableFrom(serializerClazz)))
-                throw new RuntimeException("annotated serializer class is not a subclass of com.netflix.astyanax.Serializer. " + serializerClazz.getCanonicalName());
-            // invoke public static get() method
-            try {
-                Method getInstanceMethod = serializerClazz.getMethod("get");
-                serializer = (com.netflix.astyanax.Serializer<?>) getInstanceMethod.invoke(null);
-            } catch(Exception e) {
-                throw new RuntimeException("Failed to get or invoke public static get() method", e);
-            }
-        } else {
-            // otherwise automatically infer the Serializer type from field object type
-            serializer = SerializerTypeInferer.getSerializer(field.getType());
-        }
+		if (hasSerializerAnnotation(field)) {
+			serializer = retrieveSerializerFromAnnotation(field);
+		} else {
+			
+			Class<?> type;
+			if (isMapOrSet(field.getType())) {
+				type = getGenericTypeClass(field);
+			} else {
+				type = field.getType();
+			}
+			serializer = SerializerTypeInferer.getSerializer(type);
+		
+		}
         return serializer;
     }
 
-    static String getEntityName(Entity entityAnnotation, Class<?> clazz) {
+    private static com.netflix.astyanax.Serializer<?> retrieveSerializerFromAnnotation(Field field) {
+    	Serializer serializerAnnotation = field.getAnnotation(Serializer.class);
+        final Class<?> serializerClazz = serializerAnnotation.value();
+        
+        // check type
+        if(!(com.netflix.astyanax.Serializer.class.isAssignableFrom(serializerClazz)))
+            throw new RuntimeException("annotated serializer class is not a subclass of com.netflix.astyanax.Serializer. " + serializerClazz.getCanonicalName());
+        
+        // invoke public static get() method
+        try {
+            Method getInstanceMethod = serializerClazz.getMethod("get");
+            return (com.netflix.astyanax.Serializer<?>) getInstanceMethod.invoke(null);
+        } catch(Exception e) {
+            throw new RuntimeException("Failed to get or invoke public static get() method", e);
+        }
+	}
+
+	private static boolean hasSerializerAnnotation(Field field) {
+    	return field.getAnnotation(Serializer.class)!=null;
+	}
+
+	private static boolean isMapOrSet(Class<?> type) {
+    	boolean result = Map.class.isAssignableFrom(type);
+		result |= Set.class.isAssignableFrom(type);
+		
+		return result;
+	}
+    
+    static Class<?> getGenericTypeClass(Field field){
+        ParameterizedType stringListType = (ParameterizedType) field.getGenericType();
+        return (Class<?>) stringListType.getActualTypeArguments()[0];
+    }
+    
+	static String getEntityName(Entity entityAnnotation, Class<?> clazz) {
         String name = entityAnnotation.name();
         if (name == null || name.isEmpty()) 
             return StringUtils.substringAfterLast(clazz.getName(), ".").toLowerCase();
         else
             return name;
     }
-
-
 }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MappingUtils.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MappingUtils.java
@@ -6,6 +6,7 @@ import java.lang.reflect.ParameterizedType;
 import java.util.Map;
 import java.util.Set;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 
 import org.apache.commons.lang.StringUtils;
@@ -74,4 +75,17 @@ public class MappingUtils {
         else
             return name;
     }
+	
+	static int countColumnFields(Class<?> clazz){
+		Field[] fields = clazz.getDeclaredFields();
+		
+		int count=0;
+		for(Field field : fields){
+			if(field.isAnnotationPresent(Column.class)){
+				count +=1;
+			}
+		}
+		
+		return count;
+	}
 }

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MappingUtils.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MappingUtils.java
@@ -3,34 +3,41 @@ package com.netflix.astyanax.entitystore;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
-import java.util.Map;
-import java.util.Set;
-
+import java.lang.reflect.Type;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
 import org.apache.commons.lang.StringUtils;
 
+import com.google.common.base.Preconditions;
 import com.netflix.astyanax.serializers.SerializerTypeInferer;
 
 public class MappingUtils {
 	
+	/**
+	 * will be inferred from the type of Field if field has no explicit {@link Serializer}
+	 * @param field
+	 * @return
+	 */
     static com.netflix.astyanax.Serializer<?> getSerializerForField(Field field) {
+    	
+       return getSerializer(field, field.getType());
+    }
+    
+    /**
+     * will be inferred from the argument clazz if field has no explicit {@link Serializer}
+     * @param field
+     * @param clazz
+     * @return
+     */
+    static com.netflix.astyanax.Serializer<?> getSerializer(Field field, Class<?> clazz) {
         com.netflix.astyanax.Serializer<?> serializer = null;
         
         // check if there is explicit @Serializer annotation first
 		if (hasSerializerAnnotation(field)) {
 			serializer = retrieveSerializerFromAnnotation(field);
 		} else {
-			
-			Class<?> type;
-			if (isMapOrSet(field.getType())) {
-				type = getGenericTypeClass(field);
-			} else {
-				type = field.getType();
-			}
-			serializer = SerializerTypeInferer.getSerializer(type);
-		
+			serializer = SerializerTypeInferer.getSerializer(clazz);
 		}
         return serializer;
     }
@@ -55,18 +62,14 @@ public class MappingUtils {
 	private static boolean hasSerializerAnnotation(Field field) {
     	return field.getAnnotation(Serializer.class)!=null;
 	}
-
-	private static boolean isMapOrSet(Class<?> type) {
-    	boolean result = Map.class.isAssignableFrom(type);
-		result |= Set.class.isAssignableFrom(type);
-		
-		return result;
-	}
     
-    static Class<?> getGenericTypeClass(Field field){
-        ParameterizedType stringListType = (ParameterizedType) field.getGenericType();
-        return (Class<?>) stringListType.getActualTypeArguments()[0];
-    }
+	static Class<?> getGenericTypeClass(Field field, int index){
+		ParameterizedType stringListType = (ParameterizedType) field.getGenericType();
+		Type[] actualTypes = stringListType.getActualTypeArguments();
+		Preconditions.checkElementIndex(index, actualTypes.length);
+		
+        return (Class<?>) stringListType.getActualTypeArguments()[index];
+	}
     
 	static String getEntityName(Entity entityAnnotation, Class<?> clazz) {
         String name = entityAnnotation.name();

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SetColumnMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SetColumnMapper.java
@@ -22,8 +22,8 @@ public class SetColumnMapper extends AbstractColumnMapper {
 
     public SetColumnMapper(Field field) {
         super(field);
-        this.clazz = MappingUtils.getGenericTypeClass(field);
-        this.serializer = MappingUtils.getSerializerForField(field);
+        this.clazz = MappingUtils.getGenericTypeClass(field, 0);
+        this.serializer = MappingUtils.getSerializer(field, clazz);
     }
 
     @Override

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SetColumnMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SetColumnMapper.java
@@ -41,8 +41,10 @@ public class SetColumnMapper extends AbstractColumnMapper {
                 throw new IllegalArgumentException("cannot write non-nullable column with null value: " + columnName);
         }
         
+        int count = 0;
         for (Object entry : set) {
-            clm.putEmptyColumn(prefix + columnName + "." + entry.toString(), null);
+        	clm.putColumn(prefix + columnName + "." + count, entry.toString());
+        	count++;
         }
         return true;
     }
@@ -54,11 +56,8 @@ public class SetColumnMapper extends AbstractColumnMapper {
             set = Sets.newHashSet();
             field.set(entity,  set);
         }
-        
-        String value = name.next();
-        if (name.hasNext())
-            return false;
-        set.add(serializer.fromByteBuffer(serializer.fromString(value)));
+
+        set.add(serializer.fromByteBuffer(serializer.fromString(column.getStringValue())));
         return true;
     }
 

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SetColumnMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SetColumnMapper.java
@@ -22,10 +22,8 @@ public class SetColumnMapper extends AbstractColumnMapper {
 
     public SetColumnMapper(Field field) {
         super(field);
-        
-        ParameterizedType stringListType = (ParameterizedType) field.getGenericType();
-        this.clazz = (Class<?>) stringListType.getActualTypeArguments()[0];
-        this.serializer       = SerializerTypeInferer.getSerializer(this.clazz);
+        this.clazz = MappingUtils.getGenericTypeClass(field);
+        this.serializer = MappingUtils.getSerializerForField(field);
     }
 
     @Override

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/DefaultEntityManagerTest.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/DefaultEntityManagerTest.java
@@ -170,6 +170,7 @@ public class DefaultEntityManagerTest {
 		Foo foo1 = new Foo(prng.nextInt(), RandomStringUtils.randomAlphanumeric(4));
 		Foo foo2 = new Foo(prng.nextInt(), RandomStringUtils.randomAlphanumeric(4));
 		entity.setFooSet(ImmutableSet.of(foo1, foo2));
+		entity.setFooMap(ImmutableMap.of("K1", foo2, "K2", foo1));
 		return entity;
 	}
 

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/DefaultEntityManagerTest.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/DefaultEntityManagerTest.java
@@ -167,6 +167,9 @@ public class DefaultEntityManagerTest {
 		bar.s = RandomStringUtils.randomAlphanumeric(4);
 		bar.barbar = barbar;
 		entity.setBar(bar);
+		Foo foo1 = new Foo(prng.nextInt(), RandomStringUtils.randomAlphanumeric(4));
+		Foo foo2 = new Foo(prng.nextInt(), RandomStringUtils.randomAlphanumeric(4));
+		entity.setFooSet(ImmutableSet.of(foo1, foo2));
 		return entity;
 	}
 

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/DefaultEntityManagerTest.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/DefaultEntityManagerTest.java
@@ -94,7 +94,7 @@ public class DefaultEntityManagerTest {
 
 		keyspaceContext.start();
 
-		keyspace = keyspaceContext.getEntity();
+		keyspace = keyspaceContext.getClient();
 
 		try {
 			keyspace.dropKeyspace();

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/EntityMapperTest.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/EntityMapperTest.java
@@ -9,10 +9,7 @@ import javax.persistence.Id;
 
 import junit.framework.Assert;
 
-import org.junit.Ignore;
 import org.junit.Test;
-
-import sun.reflect.Reflection;
 
 public class EntityMapperTest {
 

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/EntityMapperTest.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/EntityMapperTest.java
@@ -9,7 +9,10 @@ import javax.persistence.Id;
 
 import junit.framework.Assert;
 
+import org.junit.Ignore;
 import org.junit.Test;
+
+import sun.reflect.Reflection;
 
 public class EntityMapperTest {
 
@@ -21,16 +24,18 @@ public class EntityMapperTest {
 		Field idField = entityMapper.getId();
 		Assert.assertEquals("id", idField.getName());
 
-		// test column number
 		Collection<ColumnMapper> cols = entityMapper.getColumnList();
-		System.out.println(cols);
-		// 19 simple + 1 nested Bar
-		Assert.assertEquals(24, cols.size());
+		// test column number
+		int actualColumnSize = cols.size();
+		int expectedColumnSize = MappingUtils.countColumnFields(SampleEntity.class);
+
+		Assert.assertEquals(expectedColumnSize, actualColumnSize);
 
 		// test field without explicit column name
 		// simple field name is used
 		boolean foundUUID = false;
 		boolean founduuid = false;
+
 		for(ColumnMapper mapper: cols) {
 			if(mapper.getColumnName().equals("UUID"))
 				foundUUID = true;
@@ -61,7 +66,7 @@ public class EntityMapperTest {
 	public void invalidColumnName() {
 		new EntityMapper<InvalidColumnNameEntity, String>(InvalidColumnNameEntity.class, null);
 	}
-
+	
 	@Test
 	public void doubleIdColumnAnnotation() {
 		EntityMapper<DoubleIdColumnEntity, String> entityMapper = new EntityMapper<DoubleIdColumnEntity, String>(DoubleIdColumnEntity.class, null);
@@ -71,9 +76,11 @@ public class EntityMapperTest {
 		Assert.assertEquals("id", idField.getName());
 
 		// test column number
-		Collection<ColumnMapper> cols = entityMapper.getColumnList();
-		System.out.println(cols);
+		int actualColumnSize = entityMapper.getColumnList().size();
+		int expectedColumnSize = MappingUtils.countColumnFields(DoubleIdColumnEntity.class);
+		// test column number
 		// 3 cols: id, num, str
-		Assert.assertEquals(3, cols.size());
+		Assert.assertEquals(expectedColumnSize, actualColumnSize);
 	}
+
 }

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/SampleEntity.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/SampleEntity.java
@@ -42,6 +42,15 @@ public class SampleEntity {
 		}
 
 		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + i;
+			result = prime * result + ((s == null) ? 0 : s.hashCode());
+			return result;
+		}
+
+		@Override
 		public boolean equals(Object obj) {
 			if (this == obj)
 				return true;
@@ -50,12 +59,16 @@ public class SampleEntity {
 			if (getClass() != obj.getClass())
 				return false;
 			Foo other = (Foo) obj;
-			if(i == other.i && s.equals(other.s))
-				return true;
-			else
+			if (i != other.i)
 				return false;
+			if (s == null) {
+				if (other.s != null)
+					return false;
+			} else if (!s.equals(other.s))
+				return false;
+			return true;
 		}
-
+		
 		@Override
 		public String toString() {		
 			try {
@@ -282,6 +295,10 @@ public class SampleEntity {
 	@Column
 	private Set<Long> longSet;
 	
+	@Column
+	@Serializer(FooSerializer.class)
+	private Set<Foo> fooSet;
+	
 	public String getId() {
 		return id;
 	}
@@ -500,5 +517,13 @@ public class SampleEntity {
     public void setLongSet(Set<Long> longSet) {
         this.longSet = longSet;
     }
+
+	public Set<Foo> getFooSet() {
+		return fooSet;
+	}
+
+	public void setFooSet(Set<Foo> fooSet) {
+		this.fooSet = fooSet;
+	}
 
 }

--- a/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/SampleEntity.java
+++ b/astyanax-entity-mapper/src/test/java/com/netflix/astyanax/entitystore/SampleEntity.java
@@ -299,6 +299,10 @@ public class SampleEntity {
 	@Serializer(FooSerializer.class)
 	private Set<Foo> fooSet;
 	
+	@Column
+	@Serializer(FooSerializer.class)
+	private Map<String, Foo> fooMap;
+	
 	public String getId() {
 		return id;
 	}
@@ -524,6 +528,14 @@ public class SampleEntity {
 
 	public void setFooSet(Set<Foo> fooSet) {
 		this.fooSet = fooSet;
+	}
+
+	public Map<String, Foo> getFooMap() {
+		return fooMap;
+	}
+
+	public void setFooMap(Map<String, Foo> fooMap) {
+		this.fooMap = fooMap;
 	}
 
 }


### PR DESCRIPTION
For custom type of Set and Map serialization.
Set:
------------

    @Column
    @Serializer(FooSerializer.class)
    private Set<Foo> fooSet;

`SetColumnMapper` gets FooSerializer from **@Serializer**.
If there is no explicit **@Serializer**, then it will inferred from `Foo`, which is the first generic type.
Map:
------------    
    @Column
    @Serializer(FooSerializer.class)
    private Map<String, Foo> fooMap;

`MapColumnMapper` gets FooSerializer from @Serializer only for **value** part, not for key.
If there is no explicit @Serializer, then it will inferred from 'Foo', which is the second generic type. It's not support custom type key for now.