### PR TITLE
Making timeouts more precise in ColumnPrefixDistributedRowLock

### DIFF
--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/locks/ColumnPrefixDistributedRowLock.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/locks/ColumnPrefixDistributedRowLock.java
@@ -248,7 +248,7 @@ public class ColumnPrefixDistributedRowLock<K> implements DistributedRowLock {
                 m.execute();
                 
                 verifyLock(curTimeMicros);
-                acquireTime = System.currentTimeMillis();
+                acquireTime = System.nanoTime();
                 return;
             }
             catch (BusyLockException e) {
@@ -325,7 +325,7 @@ public class ColumnPrefixDistributedRowLock<K> implements DistributedRowLock {
     }
     
     public boolean releaseWithMutation(MutationBatch m, boolean force) throws Exception {
-        long elapsed = System.currentTimeMillis() - acquireTime;
+        long elapsed = TimeUnit.MILLISECONDS.convert(System.nanoTime() - acquireTime, TimeUnit.NANOSECONDS);
         boolean isStale = false;
         if (timeout > 0 && elapsed > TimeUnit.MILLISECONDS.convert(timeout, this.timeoutUnits)) {
             isStale = true;


### PR DESCRIPTION
Using System.nanoTime() instead of System.currentTimeMillis() in ColumnPrefixDistributedRowLock for more precision.
