### PR TITLE
Revert 'fat jar' change from #389 on beta branch, already reverted on master, fixes #470

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,11 +69,6 @@ project(':astyanax-core') {
     dependencies {
         testCompile "junit:junit:$junitVersion"
     }
-    jar {
-        dependsOn configurations.runtime
-        baseName = 'astyanax-all'
-        from { configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) } }
-    }
 }
 
 project(':astyanax-thrift') {


### PR DESCRIPTION
The wiki for the beta branch says:

> Any updates to the master branch (thrift based changes) will be ported forward to the beta-java-driver branch.

But the graph doesn't show any merges so I just cherry-picked this change.  If you prefer to handle it differently, please let me know.  The original "fat jar" change (#389) caused two problems:
- Renamed the `astyanax-core` jar to `astyanax-all`, which also changed the artifacts and metadata generated by that subproject, but other subprojects' metadata still referred to `astyanax-core` (#470)
- Caused by default the `astyanax-core.jar` to contain all runtime dependencies -- including multiple logging libraries -- which caused runtime breakage with my downstream project because of the logger inclusions that could not be controlled any longer by transitive dependency management directives (e.g. exclude `commons-logging`).
