### PR TITLE
Issue #504: Rather than using a default CL of ONE, use at least the confi...

### DIFF
--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql3Statement.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql3Statement.java
@@ -23,11 +23,12 @@ public class ThriftCql3Statement implements CqlStatement {
     private ByteBuffer  query;
     private Compression compression = Compression.NONE;
     private RetryPolicy retry;
-    private ConsistencyLevel cl = ConsistencyLevel.CL_ONE;
+    private ConsistencyLevel cl;
     
     public ThriftCql3Statement(ThriftKeyspaceImpl keyspace) {
         this.keyspace = keyspace;
         this.retry = keyspace.getConfig().getRetryPolicy().duplicate();
+        this.cl = keyspace.getConfig().getDefaultWriteConsistencyLevel();
     }
 
     @Override


### PR DESCRIPTION
...gured

default write CL.  For read CL, the withConsistencyLevel() method is still
needed.  This, at least, is better than the current behavior of using ONE
by default, and not looking to see which CLs are configured for the
configuration.
