### PR TITLE
When require-client-auth (SSL) is enabled on server, astyanax client does not work

### DIFF
--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/SSLConnectionContext.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/SSLConnectionContext.java
@@ -27,6 +27,10 @@ public class SSLConnectionContext
     private final List<String> sslCipherSuites;
     private final String sslTruststore;
     private final String sslTruststorePassword;
+    private String keyStore;
+    private String keyPass;
+    private String keyManagerType;
+    private String keyStoreType;
 
     public SSLConnectionContext(String sslTruststore, String sslTruststorePassword){
         this(sslTruststore, sslTruststorePassword, DEFAULT_SSL_PROTOCOL, DEFAULT_SSL_CIPHER_SUITES);
@@ -37,6 +41,13 @@ public class SSLConnectionContext
         this.sslTruststorePassword = sslTruststorePassword;
         this.sslProtocol = sslProtocol;
         this.sslCipherSuites = sslCipherSuites;
+    }
+
+    public void withKeyStore(String keyStore, String keyPass, String keyManagerType, String keyStoreType) {
+        this.keyStore = keyStore;
+        this.keyPass = keyPass;
+        this.keyManagerType = keyManagerType;
+        this.keyStoreType = keyStoreType;
     }
 
     /** SSL protocol (typically, TLS) */
@@ -58,5 +69,21 @@ public class SSLConnectionContext
 
     public String getSslTruststorePassword() {
         return sslTruststorePassword;
+    }
+
+    public String getKeyStore() {
+        return keyStore;
+    }
+
+    public String getKeyPass() {
+        return keyPass;
+    }
+
+    public String getKeyManagerType() {
+        return keyManagerType;
+    }
+
+    public String getKeyStoreType() {
+        return keyStoreType;
     }
 }

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftSyncConnectionFactoryImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftSyncConnectionFactoryImpl.java
@@ -177,6 +177,7 @@ public class ThriftSyncConnectionFactoryImpl implements ConnectionFactory<Cassan
                 if(sslCxt != null) {
                     TSSLTransportParameters params = new TSSLTransportParameters(sslCxt.getSslProtocol(), sslCxt.getSslCipherSuites().toArray(new String[0]));
                     params.setTrustStore(sslCxt.getSslTruststore(), sslCxt.getSslTruststorePassword());
+                    params.setKeyStore(sslCxt.getKeyStore(), sslCxt.getKeyPass(), sslCxt.getKeyManagerType(), sslCxt.getKeyStoreType());
                     //thrift's SSL implementation does not allow you set the socket connect timeout, only read timeout
                     socket = TSSLTransportFactory.getClientSocket(getHost().getIpAddress(), getHost().getPort(), cpConfig.getSocketTimeout(), params);
                 } else {


### PR DESCRIPTION
- When Cassandra/DSE server nodes have require-client-auth specified to true, the clients need to send client cert for validation with the server nodes.  Didn't currently find a way to do with astyanax client.  Adding minor changes to accomplish that.
- When astyanax client is configured with sslcontext, now there will be a way to add client keystore using the withKeyStore method of SSLConnectionContext class
