### PR TITLE
Added support for withTimestamp via CqlPreparedStatement

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlPreparedStatement.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlPreparedStatement.java
@@ -1,6 +1,7 @@
 package com.netflix.astyanax.cql;
 
 import java.nio.ByteBuffer;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -85,4 +86,11 @@ public interface CqlPreparedStatement extends Execution<CqlStatementResult> {
      * @return
      */
     CqlPreparedStatement withUUIDValue(UUID value);
+
+    /**
+     * Set the next parameter value to this Long as a timestamp
+     * @param value
+     * @return
+     */
+    CqlPreparedStatement withTimestamp(Date value);
 }

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/AbstractPreparedCqlQuery.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/AbstractPreparedCqlQuery.java
@@ -1,19 +1,13 @@
 package com.netflix.astyanax.query;
 
 import java.nio.ByteBuffer;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
 import com.google.common.collect.Lists;
 import com.netflix.astyanax.Serializer;
-import com.netflix.astyanax.serializers.BooleanSerializer;
-import com.netflix.astyanax.serializers.DoubleSerializer;
-import com.netflix.astyanax.serializers.FloatSerializer;
-import com.netflix.astyanax.serializers.IntegerSerializer;
-import com.netflix.astyanax.serializers.LongSerializer;
-import com.netflix.astyanax.serializers.ShortSerializer;
-import com.netflix.astyanax.serializers.StringSerializer;
-import com.netflix.astyanax.serializers.UUIDSerializer;
+import com.netflix.astyanax.serializers.*;
 
 public abstract class AbstractPreparedCqlQuery<K, C> implements PreparedCqlQuery<K, C> {
     private List<ByteBuffer> values = Lists.newArrayList();
@@ -77,6 +71,11 @@ public abstract class AbstractPreparedCqlQuery<K, C> implements PreparedCqlQuery
     @Override
     public PreparedCqlQuery<K, C> withUUIDValue(UUID value) {
         return withByteBufferValue(value, UUIDSerializer.get());
+    }
+
+    @Override
+    public PreparedCqlQuery<K, C> withTimestamp(Date value) {
+        return withByteBufferValue(value, DateSerializer.get());
     }
 
 }

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedCqlQuery.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedCqlQuery.java
@@ -1,6 +1,7 @@
 package com.netflix.astyanax.query;
 
 import java.nio.ByteBuffer;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -85,4 +86,11 @@ public interface PreparedCqlQuery<K, C> extends Execution<CqlResult<K, C>> {
      * @param value
      */
     PreparedCqlQuery<K, C> withUUIDValue(UUID value);
+
+    /**
+     * Set the next parameter value to this Date
+     * @param value
+     * @return
+     */
+    PreparedCqlQuery<K, C> withTimestamp(Date value);
 }

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/direct/DirectCqlPreparedStatement.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/direct/DirectCqlPreparedStatement.java
@@ -2,6 +2,7 @@ package com.netflix.astyanax.cql.direct;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -127,8 +128,14 @@ public class DirectCqlPreparedStatement implements CqlPreparedStatement {
 		bindValues.add(value);
 		return this;
 	}
-	
-	public PreparedStatement getInnerPreparedStatement() {
+
+    @Override
+    public CqlPreparedStatement withTimestamp(Date value) {
+        bindValues.add(value);
+        return this;
+    }
+
+    public PreparedStatement getInnerPreparedStatement() {
 		return pStmt;
 	}
 }

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/DirectCqlQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/DirectCqlQueryImpl.java
@@ -2,6 +2,7 @@ package com.netflix.astyanax.cql.reads;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -124,7 +125,12 @@ public class DirectCqlQueryImpl<K, C> implements CqlQuery<K, C> {
 			return new InternalBoundStatement(pStatement).withUUIDValue(value);
 		}
 
-		@Override
+        @Override
+        public PreparedCqlQuery<K, C> withTimestamp(Date value) {
+            return new InternalBoundStatement(pStatement).withTimestamp(value);
+        }
+
+        @Override
 		public OperationResult<CqlResult<K, C>> execute() throws ConnectionException {
 			throw new NotImplementedException();
 		}
@@ -221,6 +227,12 @@ public class DirectCqlQueryImpl<K, C> implements CqlQuery<K, C> {
 			bindList.add(value);
 			return this;
 		}
+
+        @Override
+        public PreparedCqlQuery<K, C> withTimestamp(Date value) {
+            bindList.add(value);
+            return this;
+        }
 	}
 	
 	


### PR DESCRIPTION
Address issue #533 by adding usingTimestamp with Date object signature. 

Again, per DirectCqlTests - would not work locally unless I added create/drop keyspace to setup and teardown of unit tests. Please let me know if I missed something obvious in the environment setup. 
