### PR TITLE
Fixing DefaultEntityManager put and remove method

### DIFF
--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/DefaultEntityManager.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/DefaultEntityManager.java
@@ -284,7 +284,7 @@ public class DefaultEntityManager<T, K> implements EntityManager<T, K> {
         try {
             lifecycleHandler.onPreRemove(entity);
             id = entityMapper.getEntityId(entity);
-            MutationBatch mb = newMutationBatch();
+            MutationBatch mb = getMutationBatch();
             mb.withRow(columnFamily, id).delete();
             if (autoCommit)
                 mb.execute();


### PR DESCRIPTION
Entities inserted or updated via the put(T entity) method don't get persisted through a commit after multiple operations if autocommit is set to false.
Entities removed via the remove(T entity) method don't get deleted through a commit after multiple operations if autocommit is set to false.
