### PR TITLE
CompositeEntityManager now allows for reversible queries

### DIFF
--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityManager.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityManager.java
@@ -632,6 +632,7 @@ public class CompositeEntityManager<T, K> implements EntityManager<T, K> {
                                 .setStart(endpoints[0])
                                 .setEnd(endpoints[1])
                                 .setLimit(columnLimit)
+                                .setReversed(reverse)
                                 .build());
                 }
                 

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/NativeQuery.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/NativeQuery.java
@@ -23,6 +23,7 @@ public abstract class NativeQuery<T, K> {
     protected Collection<Object>      columnNames;
     protected List<ColumnPredicate>   predicates;
     protected int                     columnLimit = Integer.MAX_VALUE;
+    protected boolean                 reverse = false;
     
     /**
      * Refine query for row key
@@ -95,6 +96,11 @@ public abstract class NativeQuery<T, K> {
 
     public NativeQuery<T,K> limit(int columnLimit) {
         this.columnLimit = columnLimit;
+        return this;
+    }
+    
+    public NativeQuery<T,K> reverse(boolean reverse) {
+        this.reverse = reverse;
         return this;
     }
     


### PR DESCRIPTION
CompositeEntityManager.createNativeQuery() would create a new NativeQuery but with no option to change the ordering of the resultset in the underlying column range. I just made RangeBuilder.setReversed accessible via NativeQuery (which is currently only used within CompositeEntityManager)
