### PR TITLE
 making MaxThriftSize configurable according to yaml thrift_max_message_length_in_mb paramter

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/AstyanaxConfiguration.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/AstyanaxConfiguration.java
@@ -94,4 +94,9 @@ public interface AstyanaxConfiguration {
      * @throws Exception 
      */
     Partitioner getPartitioner(String partitionerName) throws Exception;
+
+    /**
+     * @return Return maximum thrift packet size
+     */
+    int getMaxThriftSize();
 }

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/impl/AstyanaxConfigurationImpl.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/impl/AstyanaxConfigurationImpl.java
@@ -50,6 +50,7 @@ public class AstyanaxConfigurationImpl implements AstyanaxConfiguration {
     private String              cqlVersion                  = null;
     private String              targetCassandraVersion      = "1.1";
     private Map<String, Partitioner> partitioners           = Maps.newHashMap();
+    private int                 maxThriftSize               = 16384000;
 
     public AstyanaxConfigurationImpl() {
         partitioners.put(org.apache.cassandra.dht.RandomPartitioner.class.getCanonicalName(), BigInteger127Partitioner.get());
@@ -183,4 +184,14 @@ public class AstyanaxConfigurationImpl implements AstyanaxConfiguration {
             throw new Exception("Unsupported partitioner " + partitionerName);
         return partitioner;
     }
+    public AstyanaxConfigurationImpl setMaxThriftSize(int maxthriftsize) {
+        this.maxThriftSize = maxthriftsize;
+        return this;
+    }
+
+    @Override
+    public int getMaxThriftSize() {
+        return maxThriftSize;
+    }
+
 }


### PR DESCRIPTION
Adding MaxThriftSize getter and setter to astynax configuration. 
Client can set maxThriftSize to be in sync with cassandra yaml thrift_max_message_length_in_mb parameter
@opuneet 