### PR TITLE
Fix for connection timeout.

### DIFF
--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftSyncConnectionFactoryImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftSyncConnectionFactoryImpl.java
@@ -187,10 +187,10 @@ public class ThriftSyncConnectionFactoryImpl implements ConnectionFactory<Cassan
                 socket.getSocket().setKeepAlive(true);
                 socket.getSocket().setSoLinger(false, 0);
 
-                setTimeout(cpConfig.getSocketTimeout());
                 transport = new TFramedTransport(socket);
                 if(!transport.isOpen())
                     transport.open();
+                setTimeout(cpConfig.getSocketTimeout());
 
                 cassandraClient = new Cassandra.Client(new TBinaryProtocol.Factory().getProtocol(transport));
                 monitor.incConnectionCreated(getHost());


### PR DESCRIPTION
TSocket supports only one timeout field so setting timeout or invoking
TSocket.setTimeout sets both timeout field and sets underlying java
socket's socket timeout.
TSocket is set up with cpConfig.getConnectTimeout() which sets
TSocket.timeout_ to connection timeout from Astyanax config which is as
expected but also it set's underlying java socket timeout ot connection
timeout.
Later during ThriftConnection#setTimeout both timeout and java socket
timeout set to cpConfig.getSocketTimeout.
During transport.open then socket timeout used as a connection timeout
which is not what expected.
This fix moves ThriftConnection#setTimeout to later stage so socket is
open using connection timeout and later java socket's socket timeout is
set to cpConfig.getSocketTimeout.