### PR TITLE
Signal the ShardReaderPolicy that messages were not processed…

### DIFF
--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/TimePartitionedShardReaderPolicy.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/TimePartitionedShardReaderPolicy.java
@@ -132,6 +132,7 @@ public class TimePartitionedShardReaderPolicy implements ShardReaderPolicy {
         // Shard is not in the current partition and we did't final any messages so let's just put in the
         // idle queue.  It'll be added back later when in this shard's time partition.
         // May want to randomly check an idle queue when there is nothing in the working queue
+        // A value of -1 in messagesRead means that the consumer had trouble reading messages from the shard
         if (shard.getPartition() != currentTimePartition && messagesRead == 0) {
             idleQueue.add(shard);
         }


### PR DESCRIPTION
… because of an exception while reading the messages (e.g. lock contention prevented reading)  This will cause the TimesPartitionedShardReaderPolicy to keep the shard in the work queue in these cases even if the time bucket for the card is no longer current, thus preventing the shard from going idle until the time bucket loops back.