### PR TITLE
Fixed SocketTimeoutException handling.

### DIFF
--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftSyncConnectionFactoryImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftSyncConnectionFactoryImpl.java
@@ -137,7 +137,7 @@ public class ThriftSyncConnectionFactoryImpl implements ConnectionFactory<Cassan
                     long now = System.nanoTime();
                     latency = now - startTime;
                     lastException = ThriftConverter.ToConnectionPoolException(e).setLatency(latency);
-                    if (e instanceof IsTimeoutException) {
+                    if (lastException instanceof IsTimeoutException) {
                         pool.addLatencySample(TimeUnit.NANOSECONDS.convert(cpConfig.getSocketTimeout(), TimeUnit.MILLISECONDS), now);
                     }
                     tracer.failure(lastException);
@@ -160,7 +160,7 @@ public class ThriftSyncConnectionFactoryImpl implements ConnectionFactory<Cassan
                 long now = System.nanoTime();
                 latency = now - startTime;
                 lastException = ThriftConverter.ToConnectionPoolException(e).setLatency(latency);
-                if (e instanceof IsTimeoutException) {
+                if (lastException instanceof IsTimeoutException) {
                     pool.addLatencySample(TimeUnit.NANOSECONDS.convert(cpConfig.getSocketTimeout(), TimeUnit.MILLISECONDS), now);
                 }
                 throw lastException;


### PR DESCRIPTION
During the last [FailureFriday](https://www.pagerduty.com/blog/failure-friday-at-pagerduty/) we simulated high network latency by suspending processes for two out of five Cassandra nodes in our cluster, which resulted in an unexpected service degradation.

The problem was traced back to the SmaLatencyScoreStrategyImpl not getting score updates when requests are timing out with SocketTimeoutExcpetion. Because the scores are not updated, unreachable nodes keep the highest possible score of 0.0 and remain in the available pool. In turn, the round-robin host selector gets stuck on unresponsive hosts, causing the driver to operate in a severely degraded state.

This patch addresses the issue by fixing exception handling for SocketTimeoutExceptions.
