### PR TITLE
Make compatible with Cassandra 2.2.3

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ListSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ListSerializer.java
@@ -24,7 +24,7 @@ public class ListSerializer<T> extends AbstractSerializer<List<T>> {
      * @param elements
      */
     public ListSerializer(AbstractType<T> elements) {
-        myList = ListType.getInstance(elements);
+        myList = ListType.getInstance(elements, true);
     }
 
     @Override

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/MapSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/MapSerializer.java
@@ -27,7 +27,7 @@ public class MapSerializer<K, V> extends AbstractSerializer<Map<K, V>> {
      * @param value
      */
     public MapSerializer(AbstractType<K> key, AbstractType<V> value) {
-        myMap = MapType.getInstance(key, value);
+        myMap = MapType.getInstance(key, value, true);
     }
 
     @Override

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SetSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SetSerializer.java
@@ -24,7 +24,7 @@ public class SetSerializer<T> extends AbstractSerializer<Set<T>> {
      * @param elements
      */
     public SetSerializer(AbstractType<T> elements) {
-        mySet = SetType.getInstance(elements);
+        mySet = SetType.getInstance(elements, true);
     }
 
     @Override

--- a/dependency-versions.gradle
+++ b/dependency-versions.gradle
@@ -1,5 +1,5 @@
 ext {
- cassandraVersion = "2.0.12"
+ cassandraVersion = "2.2.3"
  thriftVersion = "0.9.1"
  junitVersion = "4.8.1"
  guavaVersion = "15.0"


### PR DESCRIPTION
Make astyanax compatible with Cassandra 2.2.3, just compiled without error.
Hope that Astyanax opensource community could continue to update astyanax with the newer versions of Cassandra.