### PR TITLE
Fixing squid:S1444 - "public static" fields should be constant

### DIFF
--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/Host.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/Host.java
@@ -48,7 +48,7 @@ public class Host implements Comparable<Host> {
     private Set<String>  alternateIpAddress = Sets.newHashSet();
     private List<TokenRange> ranges = Lists.newArrayList();
 
-    public static Pattern IP_ADDR_PATTERN = Pattern
+    public static final Pattern IP_ADDR_PATTERN = Pattern
             .compile("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
 
     /**

--- a/astyanax-core/src/main/java/com/netflix/astyanax/retry/RunOnce.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/retry/RunOnce.java
@@ -18,7 +18,7 @@ package com.netflix.astyanax.retry;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 public class RunOnce implements RetryPolicy {
-    public static RunOnce instance = new RunOnce();
+    public static final RunOnce instance = new RunOnce();
 
     public static RunOnce get() {
         return instance;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/shallows/EmptyLatencyScoreStrategyImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/shallows/EmptyLatencyScoreStrategyImpl.java
@@ -23,7 +23,7 @@ import com.netflix.astyanax.connectionpool.LatencyScoreStrategy;
 
 public class EmptyLatencyScoreStrategyImpl implements LatencyScoreStrategy {
 
-    public static EmptyLatencyScoreStrategyImpl instance = new EmptyLatencyScoreStrategyImpl();
+    public static final EmptyLatencyScoreStrategyImpl instance = new EmptyLatencyScoreStrategyImpl();
 
     public static EmptyLatencyScoreStrategyImpl get() {
         return instance;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/AllRowsQueryTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/AllRowsQueryTest.java
@@ -24,7 +24,7 @@ public class AllRowsQueryTest extends KeyspaceTests {
     
 	private static final Logger LOG = LoggerFactory.getLogger(AllRowsQueryTest.class);
 	
-	public static ColumnFamily<String, String> CF_ALL_ROWS = ColumnFamily
+	public static final ColumnFamily<String, String> CF_ALL_ROWS = ColumnFamily
             .newColumnFamily(
                     "allrows", 
                     StringSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CFStandardTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CFStandardTests.java
@@ -44,13 +44,13 @@ public class CFStandardTests extends KeyspaceTests {
 	
 	private static final Logger LOG = Logger.getLogger(CFStandardTests.class);
 	
-    public static ColumnFamily<String, String> CF_STANDARD1 = ColumnFamily
+    public static final ColumnFamily<String, String> CF_STANDARD1 = ColumnFamily
             .newColumnFamily(
                     "Standard1", 
                     StringSerializer.get(),
                     StringSerializer.get());
     
-    public static ColumnFamily<String, String> CF_STANDARD2 = ColumnFamily
+    public static final ColumnFamily<String, String> CF_STANDARD2 = ColumnFamily
             .newColumnFamily(
                     "Standard2", 
                     StringSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ClickStreamTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ClickStreamTests.java
@@ -20,10 +20,10 @@ import com.netflix.astyanax.util.TimeUUIDUtils;
 
 public class ClickStreamTests extends KeyspaceTests {
 
-	public static AnnotatedCompositeSerializer<SessionEvent> SE_SERIALIZER 
+	public static final AnnotatedCompositeSerializer<SessionEvent> SE_SERIALIZER
 	= new AnnotatedCompositeSerializer<SessionEvent>(SessionEvent.class);
 
-	public static ColumnFamily<String, SessionEvent> CF_CLICK_STREAM = 
+	public static final ColumnFamily<String, SessionEvent> CF_CLICK_STREAM =
 			ColumnFamily.newColumnFamily("ClickStream", StringSerializer.get(), SE_SERIALIZER);
 
 	@BeforeClass

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CounterColumnTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CounterColumnTests.java
@@ -14,7 +14,7 @@ import com.netflix.astyanax.serializers.StringSerializer;
 
 public class CounterColumnTests extends KeyspaceTests {
 	
-    public static ColumnFamily<String, String> CF_COUNTER1 = ColumnFamily
+    public static final ColumnFamily<String, String> CF_COUNTER1 = ColumnFamily
             .newColumnFamily(
                     "Counter1", 
                     StringSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/DirectCqlTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/DirectCqlTests.java
@@ -18,13 +18,13 @@ import com.netflix.astyanax.serializers.StringSerializer;
 
 public class DirectCqlTests extends KeyspaceTests {
 	
-    public static ColumnFamily<Integer, String> CF_DIRECT = ColumnFamily
+    public static final ColumnFamily<Integer, String> CF_DIRECT = ColumnFamily
             .newColumnFamily(
                     "cfdirect", 
                     IntegerSerializer.get(),
                     StringSerializer.get());
     
-    public static ColumnFamily<String, String> CF_EMPTY_TABLE = ColumnFamily
+    public static final ColumnFamily<String, String> CF_EMPTY_TABLE = ColumnFamily
             .newColumnFamily(
                     "empty_table", 
                     StringSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/LongColumnPaginationTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/LongColumnPaginationTests.java
@@ -18,7 +18,7 @@ import com.netflix.astyanax.serializers.StringSerializer;
 
 public class LongColumnPaginationTests extends KeyspaceTests {
 	
-	public static ColumnFamily<String, Long> CF_LONGCOLUMN = ColumnFamily
+	public static final ColumnFamily<String, Long> CF_LONGCOLUMN = ColumnFamily
             .newColumnFamily(
                     "LongColumn1", 
                     StringSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RowUniquenessConstraintTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RowUniquenessConstraintTest.java
@@ -21,7 +21,7 @@ import com.netflix.astyanax.serializers.StringSerializer;
 
 public class RowUniquenessConstraintTest extends KeyspaceTests {
 
-	public static ColumnFamily<Long, String> CF_UNIQUE_CONSTRAINT = ColumnFamily
+	public static final ColumnFamily<Long, String> CF_UNIQUE_CONSTRAINT = ColumnFamily
 			.newColumnFamily(
 					"cfunique", 
 					LongSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SerializerPackageTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SerializerPackageTests.java
@@ -24,7 +24,7 @@ public class SerializerPackageTests extends KeyspaceTests {
 
 	private static final Logger LOG = Logger.getLogger(SerializerPackageTests.class);
 
-	public static ColumnFamily<String, Long> CF_SERIALIZER1 = ColumnFamily
+	public static final ColumnFamily<String, Long> CF_SERIALIZER1 = ColumnFamily
 			.newColumnFamily(
 					"Serializer1", 
 					StringSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleColumnMutationTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleColumnMutationTests.java
@@ -12,7 +12,7 @@ import com.netflix.astyanax.serializers.StringSerializer;
 
 public class SingleColumnMutationTests extends KeyspaceTests {
 
-	public static ColumnFamily<Long, String> CF_SINGLE_COLUMN = ColumnFamily
+	public static final ColumnFamily<Long, String> CF_SINGLE_COLUMN = ColumnFamily
 			.newColumnFamily(
 					"cfsinglecolmutation", 
 					LongSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/TimeUUIDTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/TimeUUIDTests.java
@@ -26,7 +26,7 @@ public class TimeUUIDTests extends KeyspaceTests {
 	
 	private static final Logger LOG = Logger.getLogger(TimeUUIDTests.class);
 	
-    public static ColumnFamily<String, UUID> CF_TIME_UUID = ColumnFamily
+    public static final ColumnFamily<String, UUID> CF_TIME_UUID = ColumnFamily
             .newColumnFamily(
                     "TimeUUID1", 
                     StringSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ChunkedObjectStoreTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ChunkedObjectStoreTest.java
@@ -19,7 +19,7 @@ import com.netflix.astyanax.serializers.StringSerializer;
 
 public class ChunkedObjectStoreTest extends KeyspaceTests {
 
-	public static ColumnFamily<String, String> CF_CHUNK = ColumnFamily.newColumnFamily("cfchunk", StringSerializer.get(), StringSerializer.get());
+	public static final ColumnFamily<String, String> CF_CHUNK = ColumnFamily.newColumnFamily("cfchunk", StringSerializer.get(), StringSerializer.get());
 
 	@BeforeClass
 	public static void init() throws Exception {

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ColumnPrefixDistributedLockTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ColumnPrefixDistributedLockTest.java
@@ -20,7 +20,7 @@ import com.netflix.astyanax.serializers.StringSerializer;
 
 public class ColumnPrefixDistributedLockTest extends KeyspaceTests {
 
-	public static ColumnFamily<String, String> CF_DIST_LOCK = ColumnFamily
+	public static final ColumnFamily<String, String> CF_DIST_LOCK = ColumnFamily
             .newColumnFamily(
                     "distlock", 
                     StringSerializer.get(),

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ColumnPrefixUniquenessConstraintTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ColumnPrefixUniquenessConstraintTest.java
@@ -22,7 +22,7 @@ import com.netflix.astyanax.serializers.StringSerializer;
 
 public class ColumnPrefixUniquenessConstraintTest extends KeyspaceTests {
 
-	public static ColumnFamily<Long, String> CF_UNIQUE_CONSTRAINT = ColumnFamily
+	public static final ColumnFamily<Long, String> CF_UNIQUE_CONSTRAINT = ColumnFamily
 			.newColumnFamily(
 					"cfunique2", 
 					LongSerializer.get(),


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1444 - "public static" fields should be constant
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1444
Please let me know if you have any questions.
Kirill Vlasov