### PR TITLE
Fixing squid:S128 - Switch cases should end with an unconditional "break" statement

### DIFF
--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlAbstractExecutionImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlAbstractExecutionImpl.java
@@ -175,7 +175,7 @@ public abstract class CqlAbstractExecutionImpl<R> implements Execution<R> {
 	
 	private ConsistencyLevel getDefaultCL(KeyspaceContext ksContext) {
 		
-		ConsistencyLevel clLevel = ksContext.getConfig().getDefaultReadConsistencyLevel(); 
+		ConsistencyLevel clLevel;
 		
 		CassandraOperationCategory op = getOperationType().getCategory();
 		switch (op) {
@@ -184,8 +184,10 @@ public abstract class CqlAbstractExecutionImpl<R> implements Execution<R> {
 			break;
 		case WRITE:
 			clLevel = ksContext.getConfig().getDefaultWriteConsistencyLevel();
+			break;
 		default:
-			clLevel = ksContext.getConfig().getDefaultReadConsistencyLevel(); 
+			clLevel = ksContext.getConfig().getDefaultReadConsistencyLevel();
+			break;
 		}
 		
 		return clLevel;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S128 - Switch cases should end with an unconditional ""break"" statement
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S128
Please let me know if you have any questions.
Kirill Vlasov