### PR TITLE
Fixing squid:S1905 - Redundant casts should not be used

### DIFF
--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlClusterImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlClusterImpl.java
@@ -310,7 +310,7 @@ public class CqlClusterImpl implements com.netflix.astyanax.Cluster, SeedHostLis
 				
 		this.cluster = builder.build(); 
 		if (!(this.cpMonitor instanceof JavaDriverConnectionPoolMonitorImpl))
-			this.cluster.getMetrics().getRegistry().addListener((MetricRegistryListener) this.metricsRegListener);
+			this.cluster.getMetrics().getRegistry().addListener(this.metricsRegListener);
 		this.session = cluster.connect();
 	}
 }

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlKeyspaceImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlKeyspaceImpl.java
@@ -398,7 +398,7 @@ public class CqlKeyspaceImpl implements Keyspace, SeedHostListener {
 					
 			cluster = builder.build();
 			if (!(this.cpMonitor instanceof JavaDriverConnectionPoolMonitorImpl))
-				this.cluster.getMetrics().getRegistry().addListener((MetricRegistryListener) this.metricsRegListener);
+				this.cluster.getMetrics().getRegistry().addListener(this.metricsRegListener);
 			
 			Logger.info("Connecting to cluster");
 			session = cluster.connect();

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlColumnQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlColumnQueryImpl.java
@@ -87,7 +87,7 @@ public class CqlColumnQueryImpl<C> implements ColumnQuery<C> {
 				return null;
 			}
 
-			CqlColumnImpl<C> cqlCol = new CqlColumnImpl<C>((C) columnName, row, 0);
+			CqlColumnImpl<C> cqlCol = new CqlColumnImpl<C>(columnName, row, 0);
 			return cqlCol;
 		}
 	}

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlColumnSlice.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlColumnSlice.java
@@ -82,7 +82,7 @@ public class CqlColumnSlice<C> extends ColumnSlice<C> {
 	}
 	
 	private void initFrom(CqlColumnSlice<C> cqlColumnSlice) {
-		this.cqlColumns = (Collection<C>) cqlColumnSlice.cqlColumns;
+		this.cqlColumns = cqlColumnSlice.cqlColumns;
 		this.cqlRange = cqlColumnSlice.cqlRange;
 	}
 
@@ -109,12 +109,12 @@ public class CqlColumnSlice<C> extends ColumnSlice<C> {
 
 	@Override
 	public C getStartColumn() {
-		return (cqlRange != null) ? (C) cqlRange.getCqlStart() : null;
+		return (cqlRange != null) ? cqlRange.getCqlStart() : null;
 	}
 
 	@Override
 	public C getEndColumn() {
-		return (cqlRange != null) ? (C) cqlRange.getCqlEnd() : null;
+		return (cqlRange != null) ? cqlRange.getCqlEnd() : null;
 	}
 
 	@Override
@@ -140,11 +140,11 @@ public class CqlColumnSlice<C> extends ColumnSlice<C> {
 		if (isColumnSelectQuery()) {
 			return false;
 		}
-		
+
 		if (cqlRange != null)  {
 			return true;
 		}
-		
+
 		return false;
 	}
 	

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlColumnFamilyDefinitionImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlColumnFamilyDefinitionImpl.java
@@ -863,7 +863,7 @@ public class CqlColumnFamilyDefinitionImpl implements ColumnFamilyDefinition {
 				}
 				node = (Map<String, Object>)node.get(parts[i]);
 			}
-			node.put(parts[parts.length-1], (String)prop.getValue());
+			node.put(parts[parts.length-1], prop.getValue());
 		}
 		return root;
 	}

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlKeyspaceDefinitionImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlKeyspaceDefinitionImpl.java
@@ -321,7 +321,7 @@ public class CqlKeyspaceDefinitionImpl implements KeyspaceDefinition {
 				}
 				node = (Map<String, Object>)node.get(parts[i]);
 			}
-			node.put(parts[parts.length-1], (String)prop.getValue());
+			node.put(parts[parts.length-1], prop.getValue());
 		}
 		return root;
 	}

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntry.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntry.java
@@ -84,7 +84,7 @@ public class MessageQueueEntry {
     }
     
     public static MessageQueueEntry newBusyEntry(Message message) {
-        return new MessageQueueEntry(MessageQueueEntryType.Message, (byte)message.getPriority(), message.getToken(), message.getRandom(), MessageQueueEntryState.Busy);
+        return new MessageQueueEntry(MessageQueueEntryType.Message, message.getPriority(), message.getToken(), message.getRandom(), MessageQueueEntryState.Busy);
     }
     
     public static MessageQueueEntry fromMetadata(MessageMetadataEntry meta) {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/ShardedDistributedMessageQueue.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/ShardedDistributedMessageQueue.java
@@ -443,7 +443,7 @@ public class ShardedDistributedMessageQueue implements MessageQueue {
     }
 
     private <T> T deserializeString(String data, Class<T> clazz) throws JsonParseException, JsonMappingException, IOException {
-        return (T) mapper.readValue(
+        return mapper.readValue(
                 new ByteArrayInputStream(data.getBytes()),
                 clazz);
     }
@@ -842,7 +842,7 @@ public class ShardedDistributedMessageQueue implements MessageQueue {
                         String groupKey = getCompositeKey(getName(), message.getKey());
                         uniqueKeys.put(groupKey, message);
                         mb.withRow(keyIndexColumnFamily, groupKey)
-                            .putEmptyColumn(lockColumn, (Integer)lockTtl);
+                            .putEmptyColumn(lockColumn, lockTtl);
                     }
                 }
 

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/AllRowsQueryTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/AllRowsQueryTest.java
@@ -44,7 +44,7 @@ public class AllRowsQueryTest extends KeyspaceTests {
             String rowKey = Character.toString(keyName);
             ColumnListMutation<String> cfmStandard = m.withRow(CF_ALL_ROWS, rowKey);
             for (char cName = 'a'; cName <= 'z'; cName++) {
-                cfmStandard.putColumn(Character.toString(cName), (int) (cName - 'a') + 1, null);
+                cfmStandard.putColumn(Character.toString(cName), cName - 'a' + 1, null);
             }
             m.withCaching(true);
             m.execute();

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CFStandardTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CFStandardTests.java
@@ -405,7 +405,7 @@ public class CFStandardTests extends KeyspaceTests {
             ColumnListMutation<String> cfmStandard = m.withRow(CF_STANDARD1, rowKey);
             for (char cName = 'a'; cName <= 'z'; cName++) {
                 cfmStandard.putColumn(Character.toString(cName),
-                        (int) (cName - 'a') + 1, null);
+                        cName - 'a' + 1, null);
             }
             m.withCaching(true);
             m.execute();

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ColumnCountQueryTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ColumnCountQueryTests.java
@@ -307,7 +307,7 @@ public class ColumnCountQueryTests extends ReadTests {
         	String rowKey = Character.toString(keyName);
         	ColumnListMutation<String> colMutation = m.withRow(CF_COLUMN_RANGE_TEST, rowKey);
               for (char cName = 'a'; cName <= 'z'; cName++) {
-            	  colMutation.putColumn(Character.toString(cName), (int) (cName - 'a') + 1, null);
+            	  colMutation.putColumn(Character.toString(cName), cName - 'a' + 1, null);
               }
               m.withCaching(true);
               m.execute();

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/PreparedStatementTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/PreparedStatementTests.java
@@ -299,7 +299,7 @@ public class PreparedStatementTests extends ReadTests {
         	String rowKey = Character.toString(keyName);
         	ColumnListMutation<String> colMutation = m.withRow(CF_ROW_RANGE, rowKey);
               for (char cName = 'a'; cName <= 'z'; cName++) {
-            	  colMutation.putColumn(Character.toString(cName), (int) (cName - 'a') + 1, null);
+            	  colMutation.putColumn(Character.toString(cName), cName - 'a' + 1, null);
               }
               m.withCaching(true);
               m.execute();

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/AllRowsReaderTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/AllRowsReaderTest.java
@@ -42,7 +42,7 @@ public class AllRowsReaderTest extends KeyspaceTests {
             String rowKey = Character.toString(keyName);
             ColumnListMutation<String> cfmStandard = m.withRow(CF_ALL_ROWS_READER, rowKey);
             for (char cName = 'a'; cName <= 'z'; cName++) {
-                cfmStandard.putColumn(Character.toString(cName), (int) (cName - 'a') + 1, null);
+                cfmStandard.putColumn(Character.toString(cName), cName - 'a' + 1, null);
             }
             m.execute();
             m.discardMutations();

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/TestUtils.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/TestUtils.java
@@ -77,7 +77,7 @@ public class TestUtils {
         	String rowKey = Character.toString(keyName);
         	ColumnListMutation<String> colMutation = m.withRow(CF_COLUMN_RANGE_TEST, rowKey);
               for (char cName = 'a'; cName <= 'z'; cName++) {
-            	  colMutation.putColumn(Character.toString(cName), (int) (cName - 'a') + 1, null);
+            	  colMutation.putColumn(Character.toString(cName), cName - 'a' + 1, null);
               }
               m.withCaching(true);
               m.execute();

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftFamilyFactory.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftFamilyFactory.java
@@ -44,13 +44,13 @@ public class ThriftFamilyFactory implements AstyanaxTypeFactory<Cassandra.Client
     @Override
     public Cluster createCluster(ConnectionPool<Cassandra.Client> cp, AstyanaxConfiguration asConfig,
             KeyspaceTracerFactory tracerFactory) {
-        return new ThriftClusterImpl(asConfig, (ConnectionPool<Cassandra.Client>) cp, tracerFactory);
+        return new ThriftClusterImpl(asConfig, cp, tracerFactory);
     }
 
     @Override
     public ConnectionFactory<Cassandra.Client> createConnectionFactory(AstyanaxConfiguration asConfig, ConnectionPoolConfiguration cfConfig,
             KeyspaceTracerFactory tracerFactory, ConnectionPoolMonitor monitor) {
-        return (ConnectionFactory<Cassandra.Client>) new ThriftSyncConnectionFactoryImpl(asConfig, cfConfig, tracerFactory,
+        return new ThriftSyncConnectionFactoryImpl(asConfig, cfConfig, tracerFactory,
                 monitor);
     }
 

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftUtils.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftUtils.java
@@ -305,7 +305,7 @@ public class ThriftUtils {
                 }
                 node = (Map<String, Object>)node.get(parts[i]);
             }
-            node.put(parts[parts.length-1], (String)prop.getValue());
+            node.put(parts[parts.length-1], prop.getValue());
         }
         return root;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1905 - Redundant casts should not be used
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1905
Please let me know if you have any questions.
Kirill Vlasov