### PR TITLE
Fixing squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/TokenPartitionedTopology.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/TokenPartitionedTopology.java
@@ -227,7 +227,7 @@ public class TokenPartitionedTopology<CL> implements Topology<CL> {
     	List<TokenHostConnectionPoolPartition<CL>> partitions = this.sortedRing.get();
         // Must have a token otherwise we default to the base class
         // implementation
-        if (token == null || partitions == null || partitions.isEmpty()) {
+        if (partitions == null || partitions.isEmpty()) {
             return getAllPools();
         }
 

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/AbstractMutationBatchImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/AbstractMutationBatchImpl.java
@@ -164,8 +164,10 @@ public abstract class AbstractMutationBatchImpl implements MutationBatch {
 		sb.append("MutationBatch[");
 		boolean first = true;
 		for (Entry<ByteBuffer, Map<String, ColumnListMutation<?>>> row : mutationMap.entrySet()) {
-			if (!first)
+			if (!first) {
 				sb.append(",");
+			}
+			first = false;
 			sb.append(Hex.encodeHex(row.getKey().array()));
 			sb.append(row.getValue().entrySet().toString());
 		}

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftKeyspaceImpl.java
@@ -635,10 +635,7 @@ public final class ThriftKeyspaceImpl implements Keyspace {
     
     private OperationResult<SchemaChangeResult> createKeyspaceIfNotExists(Callable<OperationResult<SchemaChangeResult>> createKeyspace) throws ConnectionException {
         
-    	boolean shouldCreateKeyspace = false;
-    	
-    	try { 
-    		
+    	try {
     		OperationResult<KeyspaceDefinition> opResult = this.internalDescribeKeyspace();
         	
     		if (opResult != null && opResult.getResult() != null) {
@@ -646,28 +643,20 @@ public final class ThriftKeyspaceImpl implements Keyspace {
                         new SchemaChangeResponseImpl().setSchemaId("no-op"), 
                         opResult.getLatency());
 
-        	} else {
-        		shouldCreateKeyspace = true;
         	}
         } catch (BadRequestException e) {
-        	if (e.isKeyspaceDoestNotExist()) {
-        		shouldCreateKeyspace = true;
-        	} else {
-        		throw e;
+        	if (!e.isKeyspaceDoestNotExist()) {
+                throw e;
         	}
         }
     	
-    	if (shouldCreateKeyspace) {
-    		try {
-				return createKeyspace.call();
-			} catch (ConnectionException e) {
-				throw e;
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-    	} else {
-    		throw new IllegalStateException();
-    	}
+        try {
+            return createKeyspace.call();
+        } catch (ConnectionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2583
Please let me know if you have any questions.
Kirill Vlasov