### PR TITLE
Fixing squid:S1481 - Unused local variables should be removed

### DIFF
--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityMapper.java
@@ -135,7 +135,6 @@ public class CompositeEntityMapper<T, K> {
 
         Field[] declaredFields = clazz.getDeclaredFields();
         FieldMapper tempIdMapper = null;
-        CompositeColumnEntityMapper tempEmbeddedEntityMapper = null;
         for (Field field : declaredFields) {
             // Should only have one id field and it should map to the row key
             Id idAnnotation = field.getAnnotation(Id.class);

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/storage/ObjectReader.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/storage/ObjectReader.java
@@ -117,7 +117,6 @@ public class ObjectReader implements Callable<ObjectMetadata> {
 
             final AtomicReference<Exception> exception = new AtomicReference<Exception>();
             final AtomicLong totalBytesRead = new AtomicLong();
-            final AtomicLong totalBytesRead2 = new AtomicLong();
 
             // Iterate sequentially building up the batches. Once a complete
             // batch of ids is ready

--- a/astyanax-test/src/test/java/com/netflix/astyanax/recipes/MiscUnitTest.java
+++ b/astyanax-test/src/test/java/com/netflix/astyanax/recipes/MiscUnitTest.java
@@ -252,9 +252,7 @@ public class MiscUnitTest {
             // ...
             //
 
-            MutationBatch m;
-            OperationResult<Void> result;
-            m = keyspace.prepareMutationBatch();
+            MutationBatch m = keyspace.prepareMutationBatch();
 
             for (char keyName = 'A'; keyName <= 'Z'; keyName++) {
                 String rowKey = Character.toString(keyName);
@@ -273,8 +271,6 @@ public class MiscUnitTest {
             m.withRow(CF_STANDARD1, "Prefixes").putColumn("Prefix1_a", 1, null)
                     .putColumn("Prefix1_b", 2, null)
                     .putColumn("prefix2_a", 3, null);
-
-            result = m.execute();
 
             m.execute();
             
@@ -308,7 +304,7 @@ public class MiscUnitTest {
                   .withRow(CF_EMAIL_UNIQUE_UUID, "user1@domain.com");
         
         try {
-            Column<UUID> c = constraint.getUniqueColumn();
+            constraint.getUniqueColumn();
             Assert.fail();
         }
         catch (Exception e) {
@@ -693,7 +689,7 @@ public class MiscUnitTest {
         }
         
         try {
-            String data = unique.readDataAsString();
+            unique.readDataAsString();
             Assert.fail();
         }
         catch (Exception e) {
@@ -1039,7 +1035,7 @@ public class MiscUnitTest {
         Future<Boolean> future = Executors.newSingleThreadExecutor().submit(reader);        
         
         try {
-            boolean result = future.get();
+            future.get();
             Assert.fail();
         }
         catch (Exception e) {

--- a/astyanax-test/src/test/java/com/netflix/astyanax/thrift/ThriftKeyspaceImplTest.java
+++ b/astyanax-test/src/test/java/com/netflix/astyanax/thrift/ThriftKeyspaceImplTest.java
@@ -382,9 +382,7 @@ public class ThriftKeyspaceImplTest {
             // ...
             //
 
-            MutationBatch m;
-            OperationResult<Void> result;
-            m = keyspace.prepareMutationBatch();
+            MutationBatch m = keyspace.prepareMutationBatch();
 
             for (char keyName = 'A'; keyName <= 'Z'; keyName++) {
                 String rowKey = Character.toString(keyName);
@@ -404,7 +402,7 @@ public class ThriftKeyspaceImplTest {
                     .putColumn("Prefix1_b", 2, null)
                     .putColumn("prefix2_a", 3, null);
 
-            result = m.execute();
+            m.execute();
 
             String rowKey = "A";
             ColumnListMutation<Long> cfmLong = m.withRow(CF_LONGCOLUMN, rowKey);
@@ -412,7 +410,7 @@ public class ThriftKeyspaceImplTest {
                 cfmLong.putEmptyColumn(l, null);
             }
             cfmLong.putEmptyColumn(Long.MAX_VALUE, null);
-            result = m.execute();
+            m.execute();
 
             m.withRow(CF_USER_INFO, "acct1234")
                 .putColumn("firstname", "john", null)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1481 - Unused local variables should be removed
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1481
Please let me know if you have any questions.
Kirill Vlasov