### PR TITLE
Add wildcard exclusions

### DIFF
--- a/astyanax-cassandra/build.gradle
+++ b/astyanax-cassandra/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile ("org.apache.cassandra:cassandra-all:$cassandraVersion") {
        force = true
        transitive = false
+       exclude group: '*', module: '*'
     }
     compile "org.xerial.snappy:snappy-java:$snappyVersion"
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"


### PR DESCRIPTION
Adding `transitive = false` to a dependency only affects the project at build time, it's not reflected in the published artifacts. This adds `*` exclusions to the dependency so undesirable transitive dependencies don't leak to downstream consumers of the library.