### PR TITLE
Add missing license headers

### DIFF
--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/AstyanaxContext.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/AstyanaxContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import java.util.Arrays;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/AstyanaxTypeFactory.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/AstyanaxTypeFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import com.netflix.astyanax.connectionpool.ConnectionFactory;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/CassandraOperationCategory.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/CassandraOperationCategory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 public enum CassandraOperationCategory {

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/CassandraOperationTracer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/CassandraOperationTracer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/CassandraOperationType.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/CassandraOperationType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 public enum CassandraOperationType {

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/KeyspaceTracerFactory.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/KeyspaceTracerFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import com.netflix.astyanax.model.ColumnFamily;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/MultiMutationBatchManager.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/MultiMutationBatchManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import java.util.Map;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/MutationBatchManager.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/MutationBatchManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/RowCallback.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/RowCallback.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/RowCopier.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/RowCopier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 public interface RowCopier<K, C> extends Execution<Void> {

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/Serializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/Serializer.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  *  DataSerializer.java
  *  dsmirnov Apr 4, 2011
  */

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/SerializerPackage.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/SerializerPackage.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/ThreadLocalMutationBatchManager.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/ThreadLocalMutationBatchManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/WriteAheadEntry.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/WriteAheadEntry.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import com.netflix.astyanax.connectionpool.exceptions.WalException;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/WriteAheadLog.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/WriteAheadLog.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import com.netflix.astyanax.connectionpool.exceptions.WalException;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlPreparedStatement.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlPreparedStatement.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlSchema.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlSchema.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 public interface CqlSchema {

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlStatement.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlStatement.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import com.netflix.astyanax.Execution;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlStatementResult.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/cql/CqlStatementResult.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import com.netflix.astyanax.model.ColumnFamily;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/mapping/AnnotationSet.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/mapping/AnnotationSet.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.mapping;
 
 import java.lang.annotation.Annotation;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/mapping/Coercions.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/mapping/Coercions.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /*******************************************************************************
 * Copyright 2011 Netflix
 *

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/AbstractColumnImpl.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/AbstractColumnImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.model;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/AbstractComposite.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/AbstractComposite.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.model;
 
 import java.math.BigInteger;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/Composite.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/Composite.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.model;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/ConsistencyLevel.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/ConsistencyLevel.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  *  ConsistencyLevel.java
  *  dsmirnov Mar 31, 2011
  */

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/DynamicComposite.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/model/DynamicComposite.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.model;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/BOP20Partitioner.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/BOP20Partitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.partitioner;
 
 import java.math.BigInteger;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/BigInteger127Partitioner.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/BigInteger127Partitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.partitioner;
 
 import java.math.BigInteger;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/LongBOPPartitioner.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/LongBOPPartitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.partitioner;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/Murmur3Partitioner.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/Murmur3Partitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.partitioner;
 
 import java.math.BigInteger;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/OrderedBigIntegerPartitioner.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/partitioner/OrderedBigIntegerPartitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.partitioner;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/AbstractPreparedCqlQuery.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/AbstractPreparedCqlQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/AllRowsQuery.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/AllRowsQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 import java.math.BigInteger;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/CheckpointManager.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/CheckpointManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 import java.util.SortedMap;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/ColumnPredicate.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/ColumnPredicate.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 import com.netflix.astyanax.model.Equality;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/IndexOperator.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/IndexOperator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 public enum IndexOperator {

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedCqlQuery.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedCqlQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedIndexColumnExpression.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedIndexColumnExpression.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 public interface PreparedIndexColumnExpression<K, C> {

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedIndexExpression.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedIndexExpression.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedIndexOperationExpression.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedIndexOperationExpression.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 public interface PreparedIndexOperationExpression<K, C> {

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedIndexValueExpression.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/PreparedIndexValueExpression.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/RowSliceColumnCountQuery.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/query/RowSliceColumnCountQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.query;
 
 import java.util.Map;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AbstractSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AbstractSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AnnotatedCompositeSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AnnotatedCompositeSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.lang.reflect.Field;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AsciiSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/AsciiSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/BigDecimalSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/BigDecimalSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.math.BigDecimal;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/BigIntegerSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/BigIntegerSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.math.BigInteger;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/BooleanSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/BooleanSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ByteBufferOutputStream.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ByteBufferOutputStream.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 /**

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ByteBufferSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ByteBufferSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ByteSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ByteSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/BytesArraySerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/BytesArraySerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/CharSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/CharSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ComparatorType.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ComparatorType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import com.netflix.astyanax.*;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/CompositeSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/CompositeSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/DateSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/DateSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/DoubleSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/DoubleSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/DynamicCompositeSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/DynamicCompositeSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/FloatSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/FloatSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/GzipStringSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/GzipStringSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.io.ByteArrayInputStream;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/Int32Serializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/Int32Serializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/IntegerSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/IntegerSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/JacksonSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/JacksonSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.io.ByteArrayInputStream;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/JaxbSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/JaxbSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.io.ByteArrayInputStream;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ListSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ListSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/LongSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/LongSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/MapSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/MapSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ObjectSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ObjectSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.io.ByteArrayInputStream;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/PrefixedSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/PrefixedSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ReversedSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ReversedSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SerializerPackageImpl.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SerializerPackageImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SerializerTypeInferer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SerializerTypeInferer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.math.BigDecimal;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SetSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SetSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ShortSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/ShortSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SnappyStringSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SnappyStringSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.io.ByteArrayInputStream;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SpecificCompositeSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SpecificCompositeSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SpecificReversedSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/SpecificReversedSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/StringSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/StringSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/TimeUUIDSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/TimeUUIDSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/TypeInferringSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/TypeInferringSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/UUIDSerializer.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/UUIDSerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/UnknownComparatorException.java
+++ b/astyanax-cassandra/src/main/java/com/netflix/astyanax/serializers/UnknownComparatorException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.serializers;
 
 public class UnknownComparatorException extends Exception {

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/AsyncFailedWritesLogger.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/AsyncFailedWritesLogger.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.util.concurrent.Callable;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/BestEffortSecondaryWriteStrategy.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/BestEffortSecondaryWriteStrategy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.util.Collection;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/CassBasedFailedWritesLogger.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/CassBasedFailedWritesLogger.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualKeyspaceMetadata.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualKeyspaceMetadata.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 /**

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesColumnListMutation.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesColumnListMutation.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.nio.ByteBuffer;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesColumnMutation.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesColumnMutation.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.nio.ByteBuffer;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesCqlPreparedStatement.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesCqlPreparedStatement.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.nio.ByteBuffer;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesCqlStatement.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesCqlStatement.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.util.Collections;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesDemo.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesDemo.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import com.netflix.astyanax.AstyanaxContext;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesKeyspace.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesKeyspace.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.util.Collections;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesMutationBatch.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesMutationBatch.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.nio.ByteBuffer;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesStrategy.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesStrategy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.util.Collection;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesUpdateListener.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/DualWritesUpdateListener.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 /**

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/FailedWritesLogger.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/FailedWritesLogger.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 /**

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/LogBasedFailedWritesLogger.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/LogBasedFailedWritesLogger.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/WriteMetadata.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/dualwrites/WriteMetadata.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.dualwrites;
 
 /**

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/eureka/EurekaBasedHostSupplier.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/eureka/EurekaBasedHostSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.eureka;
 
 import java.util.List;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/valve/RollingTimeWindowValve.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/valve/RollingTimeWindowValve.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.valve;
 
 import java.util.UUID;

--- a/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/valve/TimeWindowValve.java
+++ b/astyanax-contrib/src/main/java/com/netflix/astyanax/contrib/valve/TimeWindowValve.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.contrib.valve;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/astyanax-contrib/src/main/resources/log4j.xml
+++ b/astyanax-contrib/src/main/resources/log4j.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
   <appender name="stdout" class="org.apache.log4j.ConsoleAppender">

--- a/astyanax-core/src/main/java/com/netflix/astyanax/AuthenticationCredentials.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/AuthenticationCredentials.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 /**

--- a/astyanax-core/src/main/java/com/netflix/astyanax/ExceptionCallback.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/ExceptionCallback.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax;
 
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/clock/ConstantClock.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/clock/ConstantClock.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.clock;
 
 import com.netflix.astyanax.Clock;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/clock/MicrosecondsAsyncClock.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/clock/MicrosecondsAsyncClock.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.clock;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/clock/MicrosecondsClock.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/clock/MicrosecondsClock.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.clock;
 
 import com.netflix.astyanax.Clock;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/ConnectionContext.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/ConnectionContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 /**

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolProxy.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/ConnectionPoolProxy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 import java.util.Collection;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/HostStats.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/HostStats.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 import java.util.Date;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/JmxConnectionPoolMonitor.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/JmxConnectionPoolMonitor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 import org.apache.commons.lang.StringUtils;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/JmxConnectionPoolMonitorMBean.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/JmxConnectionPoolMonitorMBean.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 public interface JmxConnectionPoolMonitorMBean {

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/LatencyScoreStrategy.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/LatencyScoreStrategy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 import java.util.List;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/LatencyScoreStrategyType.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/LatencyScoreStrategyType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 public enum LatencyScoreStrategyType {

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/NodeDiscoveryMonitor.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/NodeDiscoveryMonitor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 public class NodeDiscoveryMonitor implements NodeDiscoveryMonitorMBean {

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/NodeDiscoveryMonitorMBean.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/NodeDiscoveryMonitorMBean.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 public interface NodeDiscoveryMonitorMBean {

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/OperationFilterFactory.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/OperationFilterFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 public interface OperationFilterFactory {

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/RateLimiter.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/RateLimiter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool;
 
 /**

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractExecutionImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractExecutionImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import com.netflix.astyanax.Execution;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractLatencyScoreStrategyImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractLatencyScoreStrategyImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.Collections;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractOperationFilter.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractOperationFilter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.nio.ByteBuffer;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractTopology.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/AbstractTopology.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.nio.ByteBuffer;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/BagOfConnectionsConnectionPoolImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/BagOfConnectionsConnectionPoolImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.List;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/ConnectionPoolMBeanManager.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/ConnectionPoolMBeanManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.lang.management.ManagementFactory;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/CountingConnectionPoolMonitor.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/CountingConnectionPoolMonitor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.Map;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/EmaLatencyScoreStrategyImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/EmaLatencyScoreStrategyImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.ArrayList;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/HostConnectionPoolPartition.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/HostConnectionPoolPartition.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.Collection;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/LeastOutstandingExecuteWithFailover.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/LeastOutstandingExecuteWithFailover.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.Iterator;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/NodeDiscoveryMonitorManager.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/NodeDiscoveryMonitorManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.lang.management.ManagementFactory;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/OldHostSupplierAdapter.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/OldHostSupplierAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.math.BigInteger;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/OperationFilterFactoryList.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/OperationFilterFactoryList.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.List;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/RoundRobinExecuteWithFailover.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/RoundRobinExecuteWithFailover.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.List;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/SimpleAuthenticationCredentials.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/SimpleAuthenticationCredentials.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.Map;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/SimpleRateLimiterImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/SimpleRateLimiterImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.concurrent.LinkedBlockingDeque;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/Slf4jConnectionPoolMonitorImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/Slf4jConnectionPoolMonitorImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import org.slf4j.Logger;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/SmaLatencyScoreStrategyImpl.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/SmaLatencyScoreStrategyImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.util.NoSuchElementException;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/TokenHostConnectionPoolPartition.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/TokenHostConnectionPoolPartition.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.math.BigInteger;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/TokenPartitionedTopology.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/TokenPartitionedTopology.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.math.BigInteger;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/Topology.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/connectionpool/impl/Topology.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.connectionpool.impl;
 
 import java.nio.ByteBuffer;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/partitioner/Partitioner.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/partitioner/Partitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.partitioner;
 
 import java.nio.ByteBuffer;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/retry/IndefiniteRetry.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/retry/IndefiniteRetry.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.retry;
 
 public class IndefiniteRetry implements RetryPolicy {

--- a/astyanax-core/src/main/java/com/netflix/astyanax/retry/RunOnceRetryPolicyFactory.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/retry/RunOnceRetryPolicyFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.retry;
 
 import com.netflix.astyanax.retry.RetryPolicy.RetryPolicyFactory;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/shallows/EmptyOperationTracer.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/shallows/EmptyOperationTracer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.shallows;
 
 import com.netflix.astyanax.connectionpool.Operation;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/shallows/EmptyPartitioner.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/shallows/EmptyPartitioner.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.shallows;
 
 import java.nio.ByteBuffer;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/test/IncreasingRateSupplier.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/test/IncreasingRateSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.test;
 
 import com.google.common.base.Supplier;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/test/ProbabalisticFunction.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/test/ProbabalisticFunction.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.test;
 
 import java.util.ArrayList;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/test/TestDriver.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/test/TestDriver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.test;
 
 import java.util.ArrayList;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/tracing/AstyanaxContext.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/tracing/AstyanaxContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.tracing;
 
 import java.util.Map;

--- a/astyanax-core/src/main/java/com/netflix/astyanax/tracing/OperationTracer.java
+++ b/astyanax-core/src/main/java/com/netflix/astyanax/tracing/OperationTracer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.tracing;
 
 import com.netflix.astyanax.connectionpool.Operation;

--- a/astyanax-core/src/main/resources/log4j.xml
+++ b/astyanax-core/src/main/resources/log4j.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
   <appender name="stdout" class="org.apache.log4j.ConsoleAppender">

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/ConsistencyLevelMapping.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/ConsistencyLevelMapping.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import com.netflix.astyanax.model.ConsistencyLevel;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlAbstractExecutionImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlAbstractExecutionImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import org.slf4j.Logger;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlClusterImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlClusterImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlFamilyFactory.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlFamilyFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlKeyspaceImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlKeyspaceImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlOperationResultImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlOperationResultImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import java.net.InetAddress;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlRingDescriber.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlRingDescriber.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import java.math.BigInteger;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlSchemaVersionReader.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlSchemaVersionReader.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import java.net.InetAddress;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/JavaDriverConfigBridge.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/JavaDriverConfigBridge.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import com.datastax.driver.core.AuthProvider;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/JavaDriverConfigBuilder.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/JavaDriverConfigBuilder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import java.util.concurrent.TimeUnit;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/JavaDriverConnectionPoolConfigurationImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/JavaDriverConnectionPoolConfigurationImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import java.util.List;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/JavaDriverConnectionPoolMonitorImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/JavaDriverConnectionPoolMonitorImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql;
 
 import java.util.Map;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/direct/DirectCqlPreparedStatement.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/direct/DirectCqlPreparedStatement.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.direct;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/direct/DirectCqlStatement.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/direct/DirectCqlStatement.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.direct;
 
 import com.datastax.driver.core.PreparedStatement;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/direct/DirectCqlStatementResultImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/direct/DirectCqlStatementResultImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.direct;
 
 import java.util.List;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFColumnQueryGen.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFColumnQueryGen.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFRowKeysQueryGen.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFRowKeysQueryGen.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.in;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFRowQueryGen.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFRowQueryGen.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.desc;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFRowRangeQueryGen.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFRowRangeQueryGen.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.gte;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFRowSliceQueryGen.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CFRowSliceQueryGen.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.desc;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlAllRowsQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlAllRowsQueryImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import java.math.BigInteger;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlColumnCountQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlColumnCountQueryImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import java.util.List;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlColumnFamilyQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlColumnFamilyQueryImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import java.util.ArrayList;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlColumnQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlColumnQueryImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import com.datastax.driver.core.ResultSet;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlRowCopier.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlRowCopier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import java.util.Iterator;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlRowQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlRowQueryImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlRowSliceColumnCountQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlRowSliceColumnCountQueryImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import java.util.HashMap;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlRowSliceQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/CqlRowSliceQueryImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/DirectCqlQueryImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/DirectCqlQueryImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/FlatTableRowQueryGen.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/FlatTableRowQueryGen.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/FlatTableRowSliceQueryGen.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/FlatTableRowSliceQueryGen.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.gte;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/QueryGenCache.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/QueryGenCache.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads;
 
 import java.util.concurrent.Callable;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlColumnImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlColumnImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlColumnListImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlColumnListImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlColumnSlice.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlColumnSlice.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 import java.util.Collection;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRangeBuilder.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRangeBuilder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 /**

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRangeImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRangeImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRowImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRowImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRowListImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRowListImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 import java.util.ArrayList;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRowListIterator.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRowListIterator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 import java.util.ArrayList;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRowSlice.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/CqlRowSlice.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 import java.util.Collection;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/DirectCqlResult.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/reads/model/DirectCqlResult.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.reads.model;
 
 import java.util.ArrayList;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/retrypolicies/ChangeConsistencyLevelRetryPolicy.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/retrypolicies/ChangeConsistencyLevelRetryPolicy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.retrypolicies;
 
 import com.datastax.driver.core.ConsistencyLevel;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/retrypolicies/JavaDriverBasedRetryPolicy.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/retrypolicies/JavaDriverBasedRetryPolicy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.retrypolicies;
 
 import com.netflix.astyanax.retry.RetryPolicy;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlColumnDefinitionImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlColumnDefinitionImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.schema;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlColumnFamilyDefinitionImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlColumnFamilyDefinitionImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.schema;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlKeyspaceDefinitionImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/schema/CqlKeyspaceDefinitionImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.schema;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/AsyncOperationResult.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/AsyncOperationResult.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.util;
 
 import java.util.concurrent.ExecutionException;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/CFQueryContext.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/CFQueryContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.util;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/ConsistencyLevelTransform.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/ConsistencyLevelTransform.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.util;
 
 import com.datastax.driver.core.ConsistencyLevel;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/CqlTypeMapping.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/CqlTypeMapping.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.util;
 
 import java.util.HashMap;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/DataTypeMapping.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/util/DataTypeMapping.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.util;
 
 import com.datastax.driver.core.DataType;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/AbstractColumnListMutationImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/AbstractColumnListMutationImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 import java.io.ByteArrayOutputStream;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/AbstractMutationBatchImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/AbstractMutationBatchImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/BatchedStatements.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/BatchedStatements.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 import java.util.ArrayList;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CFMutationQueryGen.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CFMutationQueryGen.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 import java.util.Iterator;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CqlColumnListMutationImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CqlColumnListMutationImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 import java.util.ArrayList;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CqlColumnMutationImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CqlColumnMutationImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CqlMutationBatchImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CqlMutationBatchImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 import java.nio.ByteBuffer;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CqlStyleMutationQuery.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/CqlStyleMutationQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 import java.util.List;

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/MutationQueries.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/MutationQueries.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 public class MutationQueries {

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/StatementCache.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/writes/StatementCache.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.writes;
 
 import java.util.concurrent.Callable;

--- a/astyanax-cql/src/main/resources/log4j.xml
+++ b/astyanax-cql/src/main/resources/log4j.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
   <appender name="stdout" class="org.apache.log4j.ConsoleAppender">

--- a/astyanax-cql/src/main/resources/test-log4j.properties
+++ b/astyanax-cql/src/main/resources/test-log4j.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2013 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 log4j.rootLogger=DEBUG, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/AbstractColumnMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/AbstractColumnMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/ColumnMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/ColumnMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeColumnEntityMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeColumnEntityMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeColumnMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeColumnMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityManager.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.nio.ByteBuffer;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/CompositeEntityMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/DefaultEntityManager.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/DefaultEntityManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.util.Collection;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/EntityManager.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/EntityManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.util.Collection;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/EntityMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/EntityMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/FieldMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/FieldMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/LeafColumnMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/LeafColumnMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/LifecycleEvents.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/LifecycleEvents.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Method;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MapColumnMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MapColumnMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MappingUtils.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/MappingUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/NativeQuery.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/NativeQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.util.Collection;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/Serializer.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/Serializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.annotation.Documented;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SetColumnMapper.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SetColumnMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.reflect.Field;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SimpleCompositeBuilder.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/SimpleCompositeBuilder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.nio.ByteBuffer;

--- a/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/TTL.java
+++ b/astyanax-entity-mapper/src/main/java/com/netflix/astyanax/entitystore/TTL.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.entitystore;
 
 import java.lang.annotation.Documented;

--- a/astyanax-entity-mapper/src/main/resources/log4j.xml
+++ b/astyanax-entity-mapper/src/main/resources/log4j.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
   <appender name="stdout" class="org.apache.log4j.ConsoleAppender">

--- a/astyanax-examples/src/main/java/com/netflix/astyanax/examples/AstCQLClient.java
+++ b/astyanax-examples/src/main/java/com/netflix/astyanax/examples/AstCQLClient.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.examples;
 
 import static com.netflix.astyanax.examples.ModelConstants.*;

--- a/astyanax-examples/src/main/java/com/netflix/astyanax/examples/AstClient.java
+++ b/astyanax-examples/src/main/java/com/netflix/astyanax/examples/AstClient.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.examples;
 
 import static com.netflix.astyanax.examples.ModelConstants.*;

--- a/astyanax-examples/src/main/java/com/netflix/astyanax/examples/ModelConstants.java
+++ b/astyanax-examples/src/main/java/com/netflix/astyanax/examples/ModelConstants.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.examples;
 
 public class ModelConstants {

--- a/astyanax-examples/src/main/resources/log4j.xml
+++ b/astyanax-examples/src/main/resources/log4j.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
   <appender name="stdout" class="org.apache.log4j.ConsoleAppender">

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/BaseQueueHook.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/BaseQueueHook.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.Collection;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/CountingQueueStats.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/CountingQueueStats.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.Map;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/DuplicateMessageException.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/DuplicateMessageException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 public class DuplicateMessageException extends Exception {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/KeyExistsException.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/KeyExistsException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 public class KeyExistsException extends MessageQueueException {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/Message.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/Message.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.Map;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageConsumer.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageConsumer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.Collection;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageConsumerImpl.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageConsumerImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import com.google.common.collect.Lists;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageContext.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import org.apache.commons.lang.exception.ExceptionUtils;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageHandlerFactory.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageHandlerFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import com.google.common.base.Function;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageHistory.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageHistory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.UUID;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageMetadataEntry.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageMetadataEntry.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import com.netflix.astyanax.annotations.Component;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageMetadataEntryType.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageMetadataEntryType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 public enum MessageMetadataEntryType {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageProducer.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageProducer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.Collection;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueue.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueue.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.Collection;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueDispatcher.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueDispatcher.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.Collection;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntry.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntry.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.UUID;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntryState.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntryState.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 enum MessageQueueEntryState {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntryType.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueEntryType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 enum MessageQueueEntryType {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueException.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 public class MessageQueueException extends Exception {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueHooks.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueHooks.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.Collection;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueManager.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.List;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueMetadata.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueMetadata.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.concurrent.TimeUnit;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueSettings.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueSettings.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 /**

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueShard.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueShard.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueShardStats.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueShardStats.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 public interface MessageQueueShardStats {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueStats.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageQueueStats.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 public interface MessageQueueStats {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageStatus.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/MessageStatus.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 public enum MessageStatus {

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/SendMessageResponse.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/SendMessageResponse.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.util.Collection;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/ShardLock.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/ShardLock.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 /**

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/ShardLockManager.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/ShardLockManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import com.netflix.astyanax.recipes.locks.BusyLockException;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/ShardedDistributedMessageQueue.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/ShardedDistributedMessageQueue.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import java.io.ByteArrayInputStream;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/SimpleMessageHandlerFactory.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/SimpleMessageHandlerFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue;
 
 import com.google.common.base.Function;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/KeyModShardPolicy.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/KeyModShardPolicy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.shard;
 
 import com.netflix.astyanax.recipes.queue.Message;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/ModShardPolicy.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/ModShardPolicy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.shard;
 
 import com.netflix.astyanax.recipes.queue.Message;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/NoModShardingPolicy.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/NoModShardingPolicy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.shard;
 
 import com.netflix.astyanax.recipes.queue.Message;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/ShardReaderPolicy.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/ShardReaderPolicy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.shard;
 
 import java.util.Collection;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/TimeModShardPolicy.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/TimeModShardPolicy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.shard;
 
 import com.netflix.astyanax.recipes.queue.Message;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/TimePartitionedShardReaderPolicy.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/shard/TimePartitionedShardReaderPolicy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.shard;
 
 import java.util.Collection;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/AbstractTrigger.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/AbstractTrigger.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.triggers;
 
 

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/RepeatingTrigger.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/RepeatingTrigger.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.triggers;
 
 import java.util.concurrent.TimeUnit;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/RunOnceTrigger.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/RunOnceTrigger.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.triggers;
 
 import java.util.concurrent.TimeUnit;

--- a/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/Trigger.java
+++ b/astyanax-queue/src/main/java/com/netflix/astyanax/recipes/queue/triggers/Trigger.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.queue.triggers;
 
 /**

--- a/astyanax-queue/src/main/resources/log4j.xml
+++ b/astyanax-queue/src/main/resources/log4j.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
   <appender name="stdout" class="org.apache.log4j.ConsoleAppender">

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/Callback.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/Callback.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes;
 
 public interface Callback<T> {

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/ConstantSupplier.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/ConstantSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes;
 
 import com.google.common.base.Supplier;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/DistributedMergeSort.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/DistributedMergeSort.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes;
 
 public class DistributedMergeSort {

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/ReverseIndexQuery.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/ReverseIndexQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes;
 
 import java.nio.ByteBuffer;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/Shards.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/Shards.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes;
 
 import java.nio.ByteBuffer;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/UUIDStringSupplier.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/UUIDStringSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes;
 
 import java.util.UUID;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/UniquenessConstraint.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/UniquenessConstraint.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes;
 
 import com.google.common.base.Supplier;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/UniquenessConstraintViolationMonitor.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/UniquenessConstraintViolationMonitor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes;
 
 @Deprecated

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/UniquenessConstraintWithPrefix.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/UniquenessConstraintWithPrefix.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes;
 
 import com.google.common.base.Supplier;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/ColumnCounterFunction.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/ColumnCounterFunction.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.functions;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/RowCopierFunction.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/RowCopierFunction.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.functions;
 
 import java.io.Flushable;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/RowCounterFunction.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/RowCounterFunction.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.functions;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/TraceFunction.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/functions/TraceFunction.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.functions;
 
 import java.io.IOException;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/locks/LockColumnStrategy.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/locks/LockColumnStrategy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.locks;
 
 import com.netflix.astyanax.model.ByteBufferRange;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/locks/OneStepDistributedRowLock.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/locks/OneStepDistributedRowLock.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.locks;
 
 import java.nio.ByteBuffer;

--- a/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/locks/StringRowLockColumnStrategy.java
+++ b/astyanax-recipes/src/main/java/com/netflix/astyanax/recipes/locks/StringRowLockColumnStrategy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.recipes.locks;
 
 import com.netflix.astyanax.model.ByteBufferRange;

--- a/astyanax-recipes/src/main/resources/log4j.xml
+++ b/astyanax-recipes/src/main/resources/log4j.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
   <appender name="stdout" class="org.apache.log4j.ConsoleAppender">

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/AllRowsQueryTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/AllRowsQueryTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CFStandardTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CFStandardTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.io.Serializable;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ClickStreamTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ClickStreamTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.ArrayList;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ColumnCountQueryTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ColumnCountQueryTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.Collection;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ColumnTimestampAndTTLTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/ColumnTimestampAndTTLTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import org.junit.AfterClass;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CompositeColumnTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CompositeColumnTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.ArrayList;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CompositeKeyTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CompositeKeyTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import junit.framework.Assert;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CounterColumnTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/CounterColumnTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import junit.framework.Assert;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/DirectCqlTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/DirectCqlTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import junit.framework.Assert;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/KeyspaceTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/KeyspaceTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import org.apache.log4j.PropertyConfigurator;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/LongColumnPaginationTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/LongColumnPaginationTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import junit.framework.Assert;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/MockCompositeTypeTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/MockCompositeTypeTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import junit.framework.Assert;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/PreparedStatementTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/PreparedStatementTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.Date;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RingDescribeTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RingDescribeTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.List;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RowCopierTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RowCopierTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import junit.framework.Assert;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RowSliceRowRangeQueryTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RowSliceRowRangeQueryTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.ArrayList;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RowUniquenessConstraintTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/RowUniquenessConstraintTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.UUID;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SchemaTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SchemaTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.Date;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SerializerPackageTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SerializerPackageTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.nio.ByteBuffer;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleColumnMutationTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleColumnMutationTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import org.junit.AfterClass;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleRowColumnPaginationTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleRowColumnPaginationTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.Random;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleRowColumnRangeQueryTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleRowColumnRangeQueryTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import junit.framework.Assert;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleRowQueryTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/SingleRowQueryTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.nio.ByteBuffer;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/StaticColumnFamilyTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/StaticColumnFamilyTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.ArrayList;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/TimeUUIDTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/TimeUUIDTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test;
 
 import java.util.UUID;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/entitymapper/EntityMapperTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/entitymapper/EntityMapperTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test.entitymapper;
 
 import java.util.ArrayList;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/AllRowsReaderTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/AllRowsReaderTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test.recipes;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ChunkedObjectStoreTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ChunkedObjectStoreTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test.recipes;
 
 import java.io.ByteArrayInputStream;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ColumnPrefixDistributedLockTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ColumnPrefixDistributedLockTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test.recipes;
 
 import java.util.concurrent.TimeUnit;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ColumnPrefixUniquenessConstraintTest.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/recipes/ColumnPrefixUniquenessConstraintTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test.recipes;
 
 import java.util.UUID;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/AstyanaxContextFactory.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/AstyanaxContextFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test.utils;
 
 import static com.netflix.astyanax.cql.test.utils.ClusterConfiguration.TEST_CLUSTER_NAME;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/ClusterConfiguration.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/ClusterConfiguration.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test.utils;
 
 

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/ReadTests.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/ReadTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test.utils;
 
 import java.nio.ByteBuffer;

--- a/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/TestUtils.java
+++ b/astyanax-test/src/main/java/com/netflix/astyanax/cql/test/utils/TestUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.cql.test.utils;
 
 import java.util.ArrayList;

--- a/astyanax-test/src/main/resources/log4j.xml
+++ b/astyanax-test/src/main/resources/log4j.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
   <appender name="stdout" class="org.apache.log4j.ConsoleAppender">

--- a/astyanax-test/src/main/resources/test-log4j.properties
+++ b/astyanax-test/src/main/resources/test-log4j.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2013 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 log4j.rootLogger=DEBUG, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftCqlPreparedStatement.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftCqlPreparedStatement.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import java.nio.ByteBuffer;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftCqlQuery.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/AbstractThriftCqlQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import java.nio.ByteBuffer;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftAllRowsQueryImpl.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftAllRowsQueryImpl.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import java.math.BigInteger;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql2Factory.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql2Factory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import com.netflix.astyanax.cql.CqlStatement;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql3Factory.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql3Factory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import com.netflix.astyanax.cql.CqlStatement;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql3Query.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql3Query.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import java.nio.ByteBuffer;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql3Statement.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCql3Statement.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import java.nio.ByteBuffer;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlFactory.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import com.netflix.astyanax.cql.CqlStatement;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlFactoryResolver.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlFactoryResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import java.util.regex.Matcher;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlQuery.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlQuery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import java.nio.ByteBuffer;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlSchema.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlSchema.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import java.nio.ByteBuffer;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlStatement.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlStatement.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import java.nio.ByteBuffer;

--- a/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlStatementResult.java
+++ b/astyanax-thrift/src/main/java/com/netflix/astyanax/thrift/ThriftCqlStatementResult.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.astyanax.thrift;
 
 import org.apache.cassandra.thrift.CqlResult;

--- a/astyanax-thrift/src/main/resources/log4j.xml
+++ b/astyanax-thrift/src/main/resources/log4j.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
   <appender name="stdout" class="org.apache.log4j.ConsoleAppender">


### PR DESCRIPTION
Add missing license headers prior to merging in more substantial dependency updates designed to ease migration from Astyanax to DataStax Java Driver for Apache Cassandra. 