### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects {
     group = "com.netflix.${githubProjectName}"
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     // Don't stop the build for JavaDoc errors


### PR DESCRIPTION
Hi folks,

As you might be aware, JFrog is sunsetting Bintray and JCenter: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

This is to use maven central instead of jcenter