### PR TITLE
Allow SSL options and auth provider for cql cluster

### DIFF
--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlClusterImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlClusterImpl.java
@@ -315,12 +315,17 @@ public class CqlClusterImpl implements com.netflix.astyanax.Cluster, SeedHostLis
 				.withCompression(config.getProtocolOptions().getCompression())
 				.withPoolingOptions(config.getPoolingOptions())
 				.withSocketOptions(config.getSocketOptions())
-				.withQueryOptions(config.getQueryOptions());
+				.withQueryOptions(config.getQueryOptions())
+				.withAuthProvider(config.getProtocolOptions().getAuthProvider());
 		
 		if (config.getMetricsOptions() == null) {
 			builder.withoutMetrics();
 		} else if (!config.getMetricsOptions().isJMXReportingEnabled()) {
 			builder.withoutJMXReporting();
+		}
+		
+		if (config.getProtocolOptions().getSSLOptions() != null) {
+			builder.withSSL(config.getProtocolOptions().getSSLOptions())
 		}
 				
 		this.cluster = builder.build(); 

--- a/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlKeyspaceImpl.java
+++ b/astyanax-cql/src/main/java/com/netflix/astyanax/cql/CqlKeyspaceImpl.java
@@ -403,14 +403,19 @@ public class CqlKeyspaceImpl implements Keyspace, SeedHostListener {
 					.withCompression(config.getProtocolOptions().getCompression())
 					.withPoolingOptions(config.getPoolingOptions())
 					.withSocketOptions(config.getSocketOptions())
-					.withQueryOptions(config.getQueryOptions());
+					.withQueryOptions(config.getQueryOptions())
+					.withAuthProvider(config.getProtocolOptions().getAuthProvider());
 			
 			if (config.getMetricsOptions() == null) {
 				builder.withoutMetrics();
 			} else if (!config.getMetricsOptions().isJMXReportingEnabled()) {
 				builder.withoutJMXReporting();
 			}
-					
+			
+			if (config.getProtocolOptions().getSSLOptions() != null) {
+				builder.withSSL(config.getProtocolOptions().getSSLOptions())
+			}
+
 			cluster = builder.build();
 			if (!(this.cpMonitor instanceof JavaDriverConnectionPoolMonitorImpl))
 				this.cluster.getMetrics().getRegistry().addListener((MetricRegistryListener) this.metricsRegListener);


### PR DESCRIPTION
Currently, I don't see an option to enable either SSL options or authentication provider for connection established in CQL format.